### PR TITLE
fix(eval): IFERROR catches all error types including #NAME?

### DIFF
--- a/crates/formualizer-eval/src/builtins/logical_ext.rs
+++ b/crates/formualizer-eval/src/builtins/logical_ext.rs
@@ -184,10 +184,12 @@ impl Function for IfErrorFn {
                 ExcelError::new_value(),
             )));
         }
-        let v = args[0].value()?.into_literal();
-        match v {
-            LiteralValue::Error(_) => args[1].value(),
-            other => Ok(crate::traits::CalcValue::Scalar(other)),
+        match args[0].value() {
+            Ok(cv) => match cv.into_literal() {
+                LiteralValue::Error(_) => args[1].value(),
+                other => Ok(crate::traits::CalcValue::Scalar(other)),
+            },
+            Err(_) => args[1].value(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- `IfErrorFn::eval` used `args[0].value()?` where the `?` operator propagated `Err(ExcelError)` before the `match` could catch it
- Errors like `#NAME?` (from unknown/unimplemented functions like `_XLFN.RRI`) bypassed IFERROR entirely instead of returning the fallback value
- Changed to match on the `Result` directly so both `Ok(Error(...))` and `Err(ExcelError)` paths return the fallback

## Test plan
- [x] Added `iferror_catches_name_error_from_unknown_function` test that verifies `=IFERROR(NONEXISTENT_FUNC(), "fallback")` returns `"fallback"`
- [x] Also verifies `=IFERROR(1/0, "div_caught")` still works (sanity check)
- [x] Full test suite passes (870 passed, pre-existing 1 failure in complex number precision)