### PR TITLE
feat(eval): add graph topology analysis for cell classification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-python"
-version = "0.3.0"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "formualizer",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-python"
-version = "0.3.0"
+version = "0.3.3"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "formualizer"
-version = "0.3.1"
+version = "0.3.3"
 description = "Fast Excel-formula tooling (Python bindings)"
 requires-python = ">=3.8"
 license = {text = "MIT"}

--- a/crates/formualizer-eval/src/builtins/datetime/date_parts.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/date_parts.rs
@@ -1,6 +1,6 @@
 //! Date and time component extraction functions
 
-use super::serial::{serial_to_date, serial_to_datetime};
+use super::serial::{date_to_serial, datetime_to_serial, serial_to_date, serial_to_datetime};
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
@@ -13,6 +13,8 @@ fn coerce_to_serial(arg: &ArgumentHandle) -> Result<f64, ExcelError> {
     match v {
         LiteralValue::Number(f) => Ok(f),
         LiteralValue::Int(i) => Ok(i as f64),
+        LiteralValue::Date(d) => Ok(date_to_serial(&d)),
+        LiteralValue::DateTime(dt) => Ok(datetime_to_serial(&dt)),
         LiteralValue::Text(s) => s.parse::<f64>().map_err(|_| {
             ExcelError::new_value().with_message("Date/time serial is not a valid number")
         }),

--- a/crates/formualizer-eval/src/builtins/datetime/serial.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/serial.rs
@@ -223,6 +223,46 @@ mod tests {
         assert!((time_to_fraction(&time) - 0.25).abs() < 1e-10);
     }
 
+    /// Verifies that the eval-crate serial round-trip (date_to_serial → serial_to_date)
+    /// is lossless. This test passes.
+    ///
+    /// NOTE: The cross-crate round-trip (eval's date_to_serial → common's serial_to_datetime)
+    /// has an off-by-one due to different epoch constants:
+    ///   - eval/serial.rs uses base 1899-12-31
+    ///   - common/value.rs uses EXCEL_EPOCH 1899-12-30
+    /// This causes RangeView::get_cell to return Date values shifted by ±1 day when
+    /// reading back DateTime-tagged Arrow cells. See date_parts_native.json DAY tests.
+    #[test]
+    fn date_serial_roundtrip_eval_crate() {
+        let d = NaiveDate::from_ymd_opt(2023, 6, 15).unwrap();
+        let serial = date_to_serial(&d);
+        let back = serial_to_date(serial).unwrap();
+        assert_eq!(d, back, "eval round trip failed: {d} -> {serial} -> {back}");
+
+        let d2 = NaiveDate::from_ymd_opt(1900, 2, 15).unwrap();
+        let serial2 = date_to_serial(&d2);
+        let back2 = serial_to_date(serial2).unwrap();
+        assert_eq!(d2, back2, "eval round trip failed: {d2} -> {serial2} -> {back2}");
+    }
+
+    /// Cross-crate round-trip: eval's date_to_serial → common's serial_to_datetime.
+    /// This fails due to the dual-epoch mismatch described above.
+    #[test]
+    #[ignore = "dual-epoch mismatch: eval serial.rs (base 1899-12-31) vs common value.rs (base 1899-12-30)"]
+    fn date_serial_roundtrip_cross_crate() {
+        use formualizer_common::LiteralValue;
+
+        let d = NaiveDate::from_ymd_opt(2023, 6, 15).unwrap();
+        let serial = date_to_serial(&d);
+        let back = LiteralValue::from_serial_number(serial);
+        match back {
+            LiteralValue::Date(back_date) => {
+                assert_eq!(d, back_date, "cross-crate round trip: {d} -> {serial} -> {back_date}");
+            }
+            other => panic!("expected Date, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_date_normalization() {
         // Month 13 becomes next January

--- a/crates/formualizer-eval/src/builtins/logical_ext.rs
+++ b/crates/formualizer-eval/src/builtins/logical_ext.rs
@@ -184,10 +184,12 @@ impl Function for IfErrorFn {
                 ExcelError::new_value(),
             )));
         }
-        let v = args[0].value()?.into_literal();
-        match v {
-            LiteralValue::Error(_) => args[1].value(),
-            other => Ok(crate::traits::CalcValue::Scalar(other)),
+        match args[0].value() {
+            Ok(cv) => match cv.into_literal() {
+                LiteralValue::Error(_) => args[1].value(),
+                other => Ok(crate::traits::CalcValue::Scalar(other)),
+            },
+            Err(_) => args[1].value(),
         }
     }
 }

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -1607,6 +1607,13 @@ where
         self.graph.get_cell_value(sheet, row, col)
     }
 
+    /// Analyze the dependency graph topology, returning per-cell classifications
+    /// and per-sheet/model summaries. `top_n` controls how many top drivers/outputs
+    /// are returned.
+    pub fn analyze_topology(&self, top_n: usize) -> super::topology::TopologyAnalysis {
+        super::topology::analyze(&self.graph, top_n)
+    }
+
     /// Get formula AST (if any) and current stored value for a cell
     pub fn get_cell(
         &self,

--- a/crates/formualizer-eval/src/engine/graph/indirect_folding.rs
+++ b/crates/formualizer-eval/src/engine/graph/indirect_folding.rs
@@ -1,0 +1,165 @@
+//! Constant-folding pass for INDIRECT function calls.
+//!
+//! At graph-build time, if all inputs to an INDIRECT call are static
+//! (literal strings, plain-value cell references, and `&` concatenation),
+//! we can resolve the reference string and replace the INDIRECT AST node
+//! with a normal Reference node. This makes the dependency graph correct
+//! without requiring special runtime handling.
+
+use super::DependencyGraph;
+use crate::reference::{CellRef, Coord};
+use crate::engine::vertex::VertexKind;
+use crate::SheetId;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::{ASTNode, ASTNodeType, ReferenceType};
+
+impl DependencyGraph {
+    /// Attempt to replace INDIRECT calls in the AST with resolved Reference nodes.
+    /// Only succeeds when all string-building inputs are static (plain values, no formulas).
+    pub fn try_fold_indirect(&self, ast: &mut ASTNode, current_sheet: SheetId) {
+        // Walk the AST recursively, folding INDIRECT nodes in-place
+        match &mut ast.node_type {
+            ASTNodeType::Function { name, args } => {
+                // First recurse into arguments (bottom-up folding)
+                for arg in args.iter_mut() {
+                    self.try_fold_indirect(arg, current_sheet);
+                }
+                // Then try to fold this node if it's INDIRECT
+                let is_indirect = {
+                    let upper = name.to_uppercase();
+                    upper == "INDIRECT" || upper == "_XLFN.INDIRECT"
+                };
+                if is_indirect {
+                    self.try_fold_indirect_call(ast, current_sheet);
+                }
+            }
+            ASTNodeType::BinaryOp { left, right, .. } => {
+                self.try_fold_indirect(left, current_sheet);
+                self.try_fold_indirect(right, current_sheet);
+            }
+            ASTNodeType::UnaryOp { expr, .. } => {
+                self.try_fold_indirect(expr, current_sheet);
+            }
+            ASTNodeType::Array(rows) => {
+                for row in rows.iter_mut() {
+                    for cell in row.iter_mut() {
+                        self.try_fold_indirect(cell, current_sheet);
+                    }
+                }
+            }
+            // Literals and References — nothing to fold
+            _ => {}
+        }
+    }
+
+    fn try_fold_indirect_call(&self, ast: &mut ASTNode, current_sheet: SheetId) {
+        // Extract the first argument (ref_text expression)
+        let first_arg = match &ast.node_type {
+            ASTNodeType::Function { args, .. } if !args.is_empty() => &args[0],
+            _ => return,
+        };
+
+        // Try to statically evaluate the argument to a string
+        let ref_string = match self.try_eval_static_string(first_arg, current_sheet) {
+            Some(s) => s,
+            None => return, // Not statically resolvable — leave AST unchanged
+        };
+
+        // Parse the string as an Excel reference
+        let reference = match ReferenceType::from_string(&ref_string) {
+            Ok(r) => r,
+            Err(_) => return, // Invalid reference — leave for runtime to produce #REF!
+        };
+
+        // Replace the INDIRECT call with a direct Reference node
+        ast.node_type = ASTNodeType::Reference {
+            original: ref_string,
+            reference,
+        };
+    }
+
+    fn try_eval_static_string(&self, ast: &ASTNode, current_sheet: SheetId) -> Option<String> {
+        match &ast.node_type {
+            ASTNodeType::Literal(lit) => match lit {
+                LiteralValue::Text(s) => Some(s.clone()),
+                LiteralValue::Number(n) => {
+                    // Format as integer when there's no fractional part (common for row numbers)
+                    let i = *n as i64;
+                    if (*n - i as f64).abs() < f64::EPSILON {
+                        Some(i.to_string())
+                    } else {
+                        Some(n.to_string())
+                    }
+                }
+                LiteralValue::Int(i) => Some(i.to_string()),
+                _ => None,
+            },
+
+            ASTNodeType::Reference {
+                reference: ReferenceType::Cell { sheet, row, col, .. },
+                ..
+            } => {
+                // Resolve the sheet name
+                let sheet_name = match sheet {
+                    Some(s) => s.as_str(),
+                    None => self.sheet_name(current_sheet),
+                };
+                let sheet_id = self.sheet_id(sheet_name)?;
+
+                // Look up the cell in the graph
+                let coord = Coord::from_excel(*row, *col, true, true);
+                let addr = CellRef::new(sheet_id, coord);
+                let &vid = self.cell_to_vertex.get(&addr)?;
+
+                // Only use if cell is a plain value (not a formula)
+                match self.store.kind(vid) {
+                    VertexKind::Cell => {}
+                    _ => return None, // Formula cell or other kind — not static
+                }
+
+                // Get the value
+                let val = self.get_cell_value(sheet_name, *row, *col)?;
+                match val {
+                    LiteralValue::Text(s) => Some(s),
+                    LiteralValue::Number(n) => {
+                        let i = n as i64;
+                        if (n - i as f64).abs() < f64::EPSILON {
+                            Some(i.to_string())
+                        } else {
+                            Some(n.to_string())
+                        }
+                    }
+                    LiteralValue::Int(i) => Some(i.to_string()),
+                    _ => None,
+                }
+            }
+
+            ASTNodeType::BinaryOp { op, left, right } if op == "&" => {
+                let l = self.try_eval_static_string(left, current_sheet)?;
+                let r = self.try_eval_static_string(right, current_sheet)?;
+                Some(format!("{}{}", l, r))
+            }
+
+            _ => None, // Not statically resolvable
+        }
+    }
+}
+
+/// Check whether an AST contains any INDIRECT function calls.
+pub fn contains_indirect(ast: &ASTNode) -> bool {
+    match &ast.node_type {
+        ASTNodeType::Function { name, args } => {
+            let upper = name.to_uppercase();
+            if upper == "INDIRECT" || upper == "_XLFN.INDIRECT" {
+                return true;
+            }
+            args.iter().any(contains_indirect)
+        }
+        ASTNodeType::BinaryOp { left, right, .. } => {
+            contains_indirect(left) || contains_indirect(right)
+        }
+        ASTNodeType::UnaryOp { expr, .. } => contains_indirect(expr),
+        ASTNodeType::Array(rows) => rows.iter().any(|row| row.iter().any(contains_indirect)),
+        _ => false,
+    }
+}

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -16,6 +16,7 @@ pub struct GraphInstrumentation {
 mod ast_utils;
 pub mod editor;
 mod formula_analysis;
+pub(crate) mod indirect_folding;
 mod names;
 mod range_deps;
 mod sheets;

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -615,6 +615,16 @@ impl DependencyGraph {
         &self.data_store
     }
 
+    /// Read-only access to the vertex store for topology analysis.
+    pub fn store_ref(&self) -> &VertexStore {
+        &self.store
+    }
+
+    /// Read-only access to the edge storage for topology analysis.
+    pub fn edges_ref(&self) -> &CsrMutableEdges {
+        &self.edges
+    }
+
     /// Converts a `CellRef` to a fully qualified A1-style string (e.g., "SheetName!A1").
     pub fn to_a1(&self, cell_ref: CellRef) -> String {
         format!("{}!{}", self.sheet_name(cell_ref.sheet_id), cell_ref.coord)

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -12,6 +12,7 @@ pub mod plan;
 pub mod range_view;
 pub mod scheduler;
 pub mod spill;
+pub mod topology;
 pub mod vertex;
 
 // New SoA modules

--- a/crates/formualizer-eval/src/engine/tests/indirect_tests.rs
+++ b/crates/formualizer-eval/src/engine/tests/indirect_tests.rs
@@ -1,0 +1,323 @@
+//! Tests for INDIRECT function — both runtime evaluation and constant-folding.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse as parse_formula;
+use formualizer_parse::parser::ASTNode;
+
+fn parse(formula: &str) -> ASTNode {
+    parse_formula(formula).unwrap()
+}
+
+// ── Runtime INDIRECT (set_cell_formula path) ──────────────────────────
+
+#[test]
+fn indirect_literal_string_returns_cell_value() {
+    // =INDIRECT("A1") where A1 = 42
+    let mut engine = Engine::new(TestWorkbook::default(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(42))
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 2, 1, parse("=INDIRECT(\"A1\")"))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 1),
+        Some(LiteralValue::Number(42.0))
+    );
+}
+
+#[test]
+fn indirect_literal_string_range() {
+    // =SUM(INDIRECT("A1:A3"))
+    let mut engine = Engine::new(TestWorkbook::default(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(10.0))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 2, 1, LiteralValue::Number(20.0))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 3, 1, LiteralValue::Number(30.0))
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 4, 1, parse("=SUM(INDIRECT(\"A1:A3\"))"))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 4, 1),
+        Some(LiteralValue::Number(60.0))
+    );
+}
+
+#[test]
+fn indirect_invalid_ref_string_returns_error() {
+    // =INDIRECT("!!!") should return an error (invalid reference string)
+    let mut engine = Engine::new(TestWorkbook::default(), EvalConfig::default());
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=INDIRECT(\"!!!\")"))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    match engine.get_cell_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(_)) => {} // Any error is acceptable
+        other => panic!("expected error, got {other:?}"),
+    }
+}
+
+// ── Constant-folding via bulk ingest path ─────────────────────────────
+
+#[test]
+fn indirect_constant_fold_with_concatenation() {
+    // B2 = "Sheet1", formula on C1 = INDIRECT("'"&B2&"'!A1")
+    // This should fold at ingest time since B2 is a plain value.
+    let cfg = EvalConfig::default();
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    // Set up static value cells via Arrow store
+    {
+        let mut aib = engine.begin_bulk_ingest_arrow();
+        aib.add_sheet("Sheet1", 3, 1024);
+        // Row 1: A1=100
+        aib.append_row(
+            "Sheet1",
+            &[LiteralValue::Number(100.0), LiteralValue::Empty, LiteralValue::Empty],
+        )
+        .unwrap();
+        // Row 2: A2=_, B2="Sheet1"
+        aib.append_row(
+            "Sheet1",
+            &[
+                LiteralValue::Empty,
+                LiteralValue::Text("Sheet1".to_string()),
+                LiteralValue::Empty,
+            ],
+        )
+        .unwrap();
+        aib.finish().unwrap();
+    }
+
+    // Stage formula via bulk ingest (this triggers the folding pass)
+    let mut builder = engine.begin_bulk_ingest();
+    let sheet = builder.add_sheet("Sheet1");
+    // =INDIRECT("'"&B2&"'!A1")
+    builder.add_formulas(
+        sheet,
+        vec![(1, 3, parse("=INDIRECT(\"'\"&B2&\"'!A1\")"))],
+    );
+    builder.finish().unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(100.0))
+    );
+}
+
+#[test]
+fn indirect_constant_fold_cell_ref_building_column() {
+    // R1 = "C", Q1 = "5", formula = INDIRECT(A1&B1)
+    // This constructs "C5" from plain value cells.
+    let cfg = EvalConfig::default();
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    {
+        let mut aib = engine.begin_bulk_ingest_arrow();
+        aib.add_sheet("Sheet1", 5, 1024);
+        // Row 1: A1="C", B1="5", C1=_, D1=_, E1=_
+        aib.append_row(
+            "Sheet1",
+            &[
+                LiteralValue::Text("C".to_string()),
+                LiteralValue::Text("5".to_string()),
+                LiteralValue::Empty,
+                LiteralValue::Empty,
+                LiteralValue::Empty,
+            ],
+        )
+        .unwrap();
+        // Rows 2-5
+        for _ in 0..4 {
+            aib.append_row(
+                "Sheet1",
+                &[LiteralValue::Empty, LiteralValue::Empty, LiteralValue::Empty, LiteralValue::Empty, LiteralValue::Empty],
+            )
+            .unwrap();
+        }
+        aib.finish().unwrap();
+    }
+
+    // Set C5 = 999
+    engine
+        .set_cell_value("Sheet1", 5, 3, LiteralValue::Number(999.0))
+        .unwrap();
+
+    // Stage formula: D1 = INDIRECT(A1&B1) → should fold to =C5
+    let mut builder = engine.begin_bulk_ingest();
+    let sheet = builder.add_sheet("Sheet1");
+    builder.add_formulas(sheet, vec![(1, 4, parse("=INDIRECT(A1&B1)"))]);
+    builder.finish().unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 4),
+        Some(LiteralValue::Number(999.0))
+    );
+}
+
+#[test]
+fn indirect_cross_sheet_via_bulk_ingest() {
+    // INDIRECT("'Other Sheet'!A1") with cross-sheet reference
+    let cfg = EvalConfig::default();
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    {
+        let mut aib = engine.begin_bulk_ingest_arrow();
+        aib.add_sheet("Sheet1", 2, 1024);
+        aib.add_sheet("Other Sheet", 2, 1024);
+        aib.append_row("Sheet1", &[LiteralValue::Empty, LiteralValue::Empty])
+            .unwrap();
+        aib.append_row(
+            "Other Sheet",
+            &[LiteralValue::Number(777.0), LiteralValue::Empty],
+        )
+        .unwrap();
+        aib.finish().unwrap();
+    }
+
+    // Stage formula on Sheet1: =INDIRECT("'Other Sheet'!A1")
+    let mut builder = engine.begin_bulk_ingest();
+    let sheet = builder.add_sheet("Sheet1");
+    builder.add_formulas(
+        sheet,
+        vec![(1, 1, parse("=INDIRECT(\"'Other Sheet'!A1\")"))],
+    );
+    builder.finish().unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(777.0))
+    );
+}
+
+#[test]
+fn indirect_with_formula_upstream_does_not_fold() {
+    // A1 has a formula (=B1), so INDIRECT referencing A1's value should NOT fold.
+    // The runtime IndirectFn should still resolve it (assuming the formula produces a valid ref string).
+    let cfg = EvalConfig::default();
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    {
+        let mut aib = engine.begin_bulk_ingest_arrow();
+        aib.add_sheet("Sheet1", 3, 1024);
+        // Row 1: A1=_, B1="A3"
+        aib.append_row(
+            "Sheet1",
+            &[
+                LiteralValue::Empty,
+                LiteralValue::Text("A3".to_string()),
+                LiteralValue::Empty,
+            ],
+        )
+        .unwrap();
+        // Row 2: empty
+        aib.append_row("Sheet1", &[LiteralValue::Empty, LiteralValue::Empty, LiteralValue::Empty])
+            .unwrap();
+        // Row 3: A3=500
+        aib.append_row(
+            "Sheet1",
+            &[LiteralValue::Number(500.0), LiteralValue::Empty, LiteralValue::Empty],
+        )
+        .unwrap();
+        aib.finish().unwrap();
+    }
+
+    // A1 = =B1 (formula, not static value)
+    // C1 = =INDIRECT(A1) — A1 is a formula cell, so folding should be skipped
+    let mut builder = engine.begin_bulk_ingest();
+    let sheet = builder.add_sheet("Sheet1");
+    builder.add_formulas(
+        sheet,
+        vec![
+            (1, 1, parse("=B1")),       // A1 = =B1 (produces "A3")
+            (1, 3, parse("=INDIRECT(A1)")), // C1 = =INDIRECT(A1)
+        ],
+    );
+    builder.finish().unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    // A1 should evaluate to "A3" (the text value from B1)
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Text("A3".to_string()))
+    );
+
+    // C1: INDIRECT(A1) → INDIRECT("A3") → value of A3 = 500
+    // Even without folding, the runtime IndirectFn should handle this
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(500.0))
+    );
+}
+
+#[test]
+fn indirect_inside_sum_with_constant_fold() {
+    // =SUM(INDIRECT("A1:A3")) via bulk ingest with literal string
+    let cfg = EvalConfig::default();
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    {
+        let mut aib = engine.begin_bulk_ingest_arrow();
+        aib.add_sheet("Sheet1", 1, 1024);
+        aib.append_row("Sheet1", &[LiteralValue::Number(10.0)])
+            .unwrap();
+        aib.append_row("Sheet1", &[LiteralValue::Number(20.0)])
+            .unwrap();
+        aib.append_row("Sheet1", &[LiteralValue::Number(30.0)])
+            .unwrap();
+        aib.append_row("Sheet1", &[LiteralValue::Empty]).unwrap();
+        aib.finish().unwrap();
+    }
+
+    let mut builder = engine.begin_bulk_ingest();
+    let sheet = builder.add_sheet("Sheet1");
+    builder.add_formulas(
+        sheet,
+        vec![(4, 1, parse("=SUM(INDIRECT(\"A1:A3\"))"))],
+    );
+    builder.finish().unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 4, 1),
+        Some(LiteralValue::Number(60.0))
+    );
+}
+
+#[test]
+fn indirect_xlfn_prefix_handled() {
+    // Some Excel exports prefix as _xlfn.INDIRECT
+    let mut engine = Engine::new(TestWorkbook::default(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(42))
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 2, 1, parse("=_xlfn.INDIRECT(\"A1\")"))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 1),
+        Some(LiteralValue::Number(42.0))
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -70,5 +70,6 @@ mod sumif_arrow_used_bounds;
 mod sumifs_arrow_edits;
 mod sumifs_arrow_fastpath;
 mod sumifs_cached_mask_padding;
+mod indirect_tests;
 mod used_bounds_cache;
 mod whole_column_sumifs;

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -71,5 +71,6 @@ mod sumifs_arrow_edits;
 mod sumifs_arrow_fastpath;
 mod sumifs_cached_mask_padding;
 mod indirect_tests;
+mod topology_tests;
 mod used_bounds_cache;
 mod whole_column_sumifs;

--- a/crates/formualizer-eval/src/engine/tests/topology_tests.rs
+++ b/crates/formualizer-eval/src/engine/tests/topology_tests.rs
@@ -1,0 +1,322 @@
+use super::common::create_cell_ref_ast;
+use crate::engine::topology::{CellRole, analyze};
+use crate::engine::DependencyGraph;
+use formualizer_common::LiteralValue;
+
+/// Helper: set a plain value and a formula that references cells.
+/// `refs` is a list of (sheet, row, col) that the formula depends on.
+fn set_formula_referencing(
+    graph: &mut DependencyGraph,
+    sheet: &str,
+    row: u32,
+    col: u32,
+    refs: &[(Option<&str>, u32, u32)],
+) {
+    assert!(!refs.is_empty());
+    if refs.len() == 1 {
+        let (ref_sheet, r, c) = refs[0];
+        let ast = create_cell_ref_ast(ref_sheet, r, c);
+        graph.set_cell_formula(sheet, row, col, ast).unwrap();
+    } else {
+        // Build a binary op chain: ref1 + ref2 + ...
+        let mut ast = create_cell_ref_ast(refs[0].0, refs[0].1, refs[0].2);
+        for &(ref_sheet, r, c) in &refs[1..] {
+            let right = create_cell_ref_ast(ref_sheet, r, c);
+            ast = super::common::create_binary_op_ast(ast, right, "+");
+        }
+        graph.set_cell_formula(sheet, row, col, ast).unwrap();
+    }
+}
+
+/// Diamond graph: A1→B1, A1→C1, B1→D1, C1→D1
+/// A1 = value, B1 = =A1, C1 = =A1, D1 = =B1+C1
+///
+/// Expected:
+/// - A1: key_driver, downstream_reach >= 3
+/// - D1: summary_output, upstream_depth = 2
+/// - B1, C1: passthrough
+#[test]
+fn test_diamond_graph() {
+    let mut graph = DependencyGraph::new();
+
+    // A1 = value
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(100))
+        .unwrap();
+
+    // B1 = =A1
+    set_formula_referencing(&mut graph, "Sheet1", 1, 2, &[(Some("Sheet1"), 1, 1)]);
+
+    // C1 = =A1
+    set_formula_referencing(&mut graph, "Sheet1", 1, 3, &[(Some("Sheet1"), 1, 1)]);
+
+    // D1 = =B1 + C1
+    set_formula_referencing(
+        &mut graph,
+        "Sheet1",
+        1,
+        4,
+        &[(Some("Sheet1"), 1, 2), (Some("Sheet1"), 1, 3)],
+    );
+
+    let result = analyze(&graph, 10);
+
+    // Find cells by address
+    let a1 = result
+        .cells
+        .iter()
+        .find(|c| c.address == "A1")
+        .expect("A1 should be in results");
+    let d1 = result
+        .cells
+        .iter()
+        .find(|c| c.address == "D1")
+        .expect("D1 should be in results");
+
+    assert_eq!(a1.classification, CellRole::KeyDriver);
+    assert!(
+        a1.downstream_reach >= 3,
+        "A1 downstream_reach should be >= 3, got {}",
+        a1.downstream_reach
+    );
+    assert_eq!(a1.fan_out, 2); // B1 and C1 depend on A1
+
+    assert_eq!(d1.classification, CellRole::SummaryOutput);
+    assert_eq!(d1.upstream_depth, 2);
+    assert_eq!(d1.fan_out, 0);
+
+    // B1 and C1 should be passthrough (not in cells since cells only has drivers + outputs)
+    // Verify via sheet topology
+    let sheet = &result.sheets[0];
+    assert_eq!(sheet.name, "Sheet1");
+    assert_eq!(sheet.vertex_count, 4);
+    assert_eq!(sheet.key_driver_count, 1);
+    assert_eq!(sheet.summary_output_count, 1);
+}
+
+/// Island detection: standalone cell with no edges.
+#[test]
+fn test_island_detection() {
+    let mut graph = DependencyGraph::new();
+
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(42))
+        .unwrap();
+
+    let result = analyze(&graph, 10);
+
+    // A1 should be an island — no edges, so not in cells list (cells only has drivers + outputs)
+    assert!(result.cells.is_empty());
+    assert_eq!(result.model.total_islands, 1);
+    assert_eq!(result.sheets[0].island_count, 1);
+}
+
+/// Cross-sheet: Sheet1!A1 → Sheet2!A1 (Sheet2!A1 formula references Sheet1!A1)
+#[test]
+fn test_cross_sheet() {
+    let mut graph = DependencyGraph::new();
+
+    // Sheet1!A1 = value
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(100))
+        .unwrap();
+
+    // Sheet2!A1 = =Sheet1!A1
+    set_formula_referencing(&mut graph, "Sheet2", 1, 1, &[(Some("Sheet1"), 1, 1)]);
+
+    let result = analyze(&graph, 10);
+
+    let driver = result
+        .cells
+        .iter()
+        .find(|c| c.classification == CellRole::KeyDriver)
+        .expect("should have a key driver");
+    assert_eq!(driver.sheet, "Sheet1");
+    assert!(driver.is_cross_sheet);
+
+    let output = result
+        .cells
+        .iter()
+        .find(|c| c.classification == CellRole::SummaryOutput)
+        .expect("should have a summary output");
+    assert_eq!(output.sheet, "Sheet2");
+    assert!(output.is_cross_sheet);
+
+    // Sheet edges
+    let sheet1 = result.sheets.iter().find(|s| s.name == "Sheet1").unwrap();
+    assert!(sheet1.feeds_sheets.contains(&"Sheet2".to_string()));
+
+    let sheet2 = result.sheets.iter().find(|s| s.name == "Sheet2").unwrap();
+    assert!(sheet2.fed_by_sheets.contains(&"Sheet1".to_string()));
+
+    // Model sheet_edges
+    assert!(result
+        .model
+        .sheet_edges
+        .contains(&("Sheet1".to_string(), "Sheet2".to_string())));
+}
+
+/// Linear chain: A1 → B1 → C1 → D1
+/// A1 = value, B1 = =A1, C1 = =B1, D1 = =C1
+#[test]
+fn test_linear_chain() {
+    let mut graph = DependencyGraph::new();
+
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+
+    set_formula_referencing(&mut graph, "Sheet1", 1, 2, &[(Some("Sheet1"), 1, 1)]);
+    set_formula_referencing(&mut graph, "Sheet1", 1, 3, &[(Some("Sheet1"), 1, 2)]);
+    set_formula_referencing(&mut graph, "Sheet1", 1, 4, &[(Some("Sheet1"), 1, 3)]);
+
+    let result = analyze(&graph, 10);
+
+    let a1 = result
+        .cells
+        .iter()
+        .find(|c| c.address == "A1")
+        .expect("A1 should be a key driver");
+    assert_eq!(a1.classification, CellRole::KeyDriver);
+    assert_eq!(a1.downstream_reach, 3);
+
+    let d1 = result
+        .cells
+        .iter()
+        .find(|c| c.address == "D1")
+        .expect("D1 should be a summary output");
+    assert_eq!(d1.classification, CellRole::SummaryOutput);
+    assert_eq!(d1.upstream_depth, 3);
+}
+
+/// Fan-out hub: A1 → B1, C1, D1, E1
+#[test]
+fn test_fan_out_hub() {
+    let mut graph = DependencyGraph::new();
+
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(10))
+        .unwrap();
+
+    // B1..E1 all depend on A1
+    for col in 2..=5 {
+        set_formula_referencing(&mut graph, "Sheet1", 1, col, &[(Some("Sheet1"), 1, 1)]);
+    }
+
+    let result = analyze(&graph, 10);
+
+    let a1 = result
+        .cells
+        .iter()
+        .find(|c| c.address == "A1")
+        .expect("A1 should be a key driver");
+    assert_eq!(a1.classification, CellRole::KeyDriver);
+    assert_eq!(a1.fan_out, 4);
+    assert_eq!(a1.downstream_reach, 4);
+
+    // All of B1..E1 should be summary outputs
+    let outputs: Vec<_> = result
+        .cells
+        .iter()
+        .filter(|c| c.classification == CellRole::SummaryOutput)
+        .collect();
+    assert_eq!(outputs.len(), 4);
+}
+
+/// Empty graph: no formulas, all vertices are islands
+#[test]
+fn test_empty_graph() {
+    let mut graph = DependencyGraph::new();
+
+    // Add some values but no formulas
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    graph
+        .set_cell_value("Sheet1", 2, 1, LiteralValue::Int(2))
+        .unwrap();
+    graph
+        .set_cell_value("Sheet1", 3, 1, LiteralValue::Int(3))
+        .unwrap();
+
+    let result = analyze(&graph, 10);
+
+    assert_eq!(result.model.total_vertices, 3);
+    assert_eq!(result.model.total_formulas, 0);
+    assert_eq!(result.model.total_islands, 3);
+    assert!(result.cells.is_empty());
+}
+
+/// Truly empty graph: no vertices at all
+#[test]
+fn test_no_vertices() {
+    let graph = DependencyGraph::new();
+    let result = analyze(&graph, 10);
+
+    assert_eq!(result.model.total_vertices, 0);
+    assert!(result.cells.is_empty());
+    assert!(result.sheets.is_empty());
+}
+
+/// Test top-N limiting
+#[test]
+fn test_top_n_limiting() {
+    let mut graph = DependencyGraph::new();
+
+    // Create 5 independent value→formula pairs
+    for i in 1..=5 {
+        graph
+            .set_cell_value("Sheet1", i, 1, LiteralValue::Int(i as i64))
+            .unwrap();
+        set_formula_referencing(
+            &mut graph,
+            "Sheet1",
+            i,
+            2,
+            &[(Some("Sheet1"), i, 1)],
+        );
+    }
+
+    // Request top_n = 2
+    let result = analyze(&graph, 2);
+
+    assert!(result.sheets[0].top_drivers.len() <= 2);
+    assert!(result.sheets[0].top_outputs.len() <= 2);
+    assert!(result.model.top_drivers.len() <= 2);
+    assert!(result.model.top_outputs.len() <= 2);
+}
+
+/// Test sheet topology counts
+#[test]
+fn test_sheet_topology_counts() {
+    let mut graph = DependencyGraph::new();
+
+    // Sheet1: 2 values, 2 formulas, 1 island
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    graph
+        .set_cell_value("Sheet1", 2, 1, LiteralValue::Int(2))
+        .unwrap();
+    graph
+        .set_cell_value("Sheet1", 3, 1, LiteralValue::Int(999))
+        .unwrap(); // island
+
+    // C1 = =A1 + B1
+    set_formula_referencing(
+        &mut graph,
+        "Sheet1",
+        1,
+        3,
+        &[(Some("Sheet1"), 1, 1), (Some("Sheet1"), 2, 1)],
+    );
+
+    let result = analyze(&graph, 10);
+
+    let sheet = &result.sheets[0];
+    assert_eq!(sheet.vertex_count, 4);
+    assert_eq!(sheet.formula_count, 1);
+    assert_eq!(sheet.key_driver_count, 2); // A1, B1
+    assert_eq!(sheet.summary_output_count, 1); // C1
+    assert_eq!(sheet.island_count, 1); // A3
+}

--- a/crates/formualizer-eval/src/engine/topology.rs
+++ b/crates/formualizer-eval/src/engine/topology.rs
@@ -1,0 +1,558 @@
+//! Graph-based heuristics for cell classification.
+//!
+//! Performs a single-pass O(V+E) analysis of the dependency graph, producing
+//! per-cell and per-sheet topology metrics: downstream reach, upstream depth,
+//! fan-in, fan-out, and a role classification (key driver, summary output,
+//! passthrough, island).
+
+use super::graph::DependencyGraph;
+use super::vertex::VertexKind;
+use formualizer_common::Coord as AbsCoord;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::VecDeque;
+
+// ---------------------------------------------------------------------------
+// Public data structures
+// ---------------------------------------------------------------------------
+
+/// Classification of a cell's structural role in the calculation graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CellRole {
+    /// Plain value cell with downstream dependents — a key model input.
+    KeyDriver,
+    /// Formula cell with no dependents — a terminal output.
+    SummaryOutput,
+    /// Formula cell that both consumes and produces — an intermediate calc.
+    Passthrough,
+    /// Cell with no edges in either direction — disconnected.
+    Island,
+}
+
+impl CellRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CellRole::KeyDriver => "key_driver",
+            CellRole::SummaryOutput => "summary_output",
+            CellRole::Passthrough => "passthrough",
+            CellRole::Island => "island",
+        }
+    }
+}
+
+/// Per-cell topology metrics.
+#[derive(Debug, Clone)]
+pub struct CellTopology {
+    pub sheet: String,
+    pub row: u32,
+    pub col: u32,
+    pub address: String,
+    pub classification: CellRole,
+    /// Primary score: downstream_reach for drivers, upstream_depth for outputs.
+    pub score: f64,
+    /// Number of cells that directly depend on this cell.
+    pub fan_out: u32,
+    /// Number of cells this cell directly depends on.
+    pub fan_in: u32,
+    /// Transitive count of cells affected downstream (capped at u32::MAX).
+    pub downstream_reach: u32,
+    /// Longest dependency chain depth upstream.
+    pub upstream_depth: u32,
+    /// Whether this cell has a cross-sheet dependency (in or out).
+    pub is_cross_sheet: bool,
+    /// Whether this cell contains a formula.
+    pub has_formula: bool,
+}
+
+/// Per-sheet topology summary.
+#[derive(Debug, Clone)]
+pub struct SheetTopology {
+    pub name: String,
+    pub vertex_count: u32,
+    pub formula_count: u32,
+    pub key_driver_count: u32,
+    pub summary_output_count: u32,
+    pub island_count: u32,
+    /// Top-N key drivers by downstream_reach.
+    pub top_drivers: Vec<CellTopology>,
+    /// Top-N summary outputs by upstream_depth.
+    pub top_outputs: Vec<CellTopology>,
+    /// Sheet names that this sheet feeds into.
+    pub feeds_sheets: Vec<String>,
+    /// Sheet names that feed into this sheet.
+    pub fed_by_sheets: Vec<String>,
+}
+
+/// Model-level topology summary.
+#[derive(Debug, Clone)]
+pub struct ModelTopology {
+    pub total_vertices: u32,
+    pub total_formulas: u32,
+    pub total_islands: u32,
+    pub top_drivers: Vec<CellTopology>,
+    pub top_outputs: Vec<CellTopology>,
+    /// Directed (source_sheet, target_sheet) pairs.
+    pub sheet_edges: Vec<(String, String)>,
+}
+
+/// Complete topology analysis result.
+#[derive(Debug, Clone)]
+pub struct TopologyAnalysis {
+    /// Filtered to key_drivers + summary_outputs only.
+    pub cells: Vec<CellTopology>,
+    pub sheets: Vec<SheetTopology>,
+    pub model: ModelTopology,
+}
+
+// ---------------------------------------------------------------------------
+// Core analysis
+// ---------------------------------------------------------------------------
+
+/// Analyze the dependency graph topology. `top_n` controls how many top
+/// drivers/outputs are returned per sheet and globally.
+pub fn analyze(graph: &DependencyGraph, top_n: usize) -> TopologyAnalysis {
+    // Collect all active vertices
+    let vids: Vec<_> = graph.iter_vertex_ids().collect();
+    let n = vids.len();
+    if n == 0 {
+        return empty_result();
+    }
+
+    // Map VertexId → dense index for O(1) array access
+    let mut vid_to_idx: FxHashMap<super::vertex::VertexId, usize> =
+        FxHashMap::with_capacity_and_hasher(n, Default::default());
+    for (i, &vid) in vids.iter().enumerate() {
+        vid_to_idx.insert(vid, i);
+    }
+
+    // Read per-vertex metadata
+    let store = graph.store_ref();
+    let sheet_reg = graph.sheet_reg();
+    let edges = graph.edges_ref();
+
+    let mut kinds = Vec::with_capacity(n);
+    let mut sheet_ids = Vec::with_capacity(n);
+    let mut coords: Vec<AbsCoord> = Vec::with_capacity(n);
+    let mut has_formula = Vec::with_capacity(n);
+
+    for &vid in &vids {
+        let kind = store.kind(vid);
+        kinds.push(kind);
+        sheet_ids.push(store.sheet_id(vid));
+        coords.push(store.coord(vid));
+        has_formula.push(matches!(
+            kind,
+            VertexKind::FormulaScalar | VertexKind::FormulaArray
+        ));
+    }
+
+    // Build local adjacency: deps[i] = indices this vertex depends on,
+    //                         rdeps[i] = indices that depend on this vertex.
+    // Also compute fan_in (number of dependencies) and fan_out (number of dependents).
+    let mut fan_in = vec![0u32; n]; // count of dependencies (out_edges)
+    let mut fan_out = vec![0u32; n]; // count of dependents (in_edges)
+
+    // deps_of[i] = list of dense indices that vertex i depends on
+    let mut deps_of: Vec<Vec<usize>> = vec![Vec::new(); n];
+    // rdeps_of[i] = list of dense indices that depend on vertex i
+    let mut rdeps_of: Vec<Vec<usize>> = vec![Vec::new(); n];
+
+    for (i, &vid) in vids.iter().enumerate() {
+        // out_edges(vid) returns dependencies of vid
+        let out = edges.out_edges(vid);
+        fan_in[i] = out.len() as u32;
+        for dep_vid in &out {
+            if let Some(&j) = vid_to_idx.get(dep_vid) {
+                deps_of[i].push(j);
+                rdeps_of[j].push(i);
+            }
+        }
+    }
+    // fan_out = number of reverse dependents
+    for i in 0..n {
+        fan_out[i] = rdeps_of[i].len() as u32;
+    }
+
+    // ------------------------------------------------------------------
+    // Kahn's algorithm: topological sort
+    // ------------------------------------------------------------------
+    // "in-degree" for Kahn's = number of dependencies (fan_in).
+    // Sources = vertices with no dependencies.
+    let mut in_deg: Vec<u32> = fan_in.clone();
+    let mut queue: VecDeque<usize> = VecDeque::new();
+    for i in 0..n {
+        if in_deg[i] == 0 {
+            queue.push_back(i);
+        }
+    }
+    let mut topo_order: Vec<usize> = Vec::with_capacity(n);
+    while let Some(i) = queue.pop_front() {
+        topo_order.push(i);
+        for &j in &rdeps_of[i] {
+            in_deg[j] -= 1;
+            if in_deg[j] == 0 {
+                queue.push_back(j);
+            }
+        }
+    }
+    // Vertices not in topo_order are in cycles — they get depth=0, reach=0.
+    let mut in_topo = vec![false; n];
+    for &i in &topo_order {
+        in_topo[i] = true;
+    }
+
+    // ------------------------------------------------------------------
+    // Pass 1 — forward topo order: upstream_depth
+    // upstream_depth[v] = max(upstream_depth[dep] + 1) over all deps
+    // ------------------------------------------------------------------
+    let mut upstream_depth = vec![0u32; n];
+    for &i in &topo_order {
+        for &dep in &deps_of[i] {
+            let candidate = upstream_depth[dep].saturating_add(1);
+            if candidate > upstream_depth[i] {
+                upstream_depth[i] = candidate;
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Pass 2 — reverse topo order: downstream_reach
+    // downstream_reach[v] = 1 + sum(downstream_reach[d]) for each dependent d
+    // Capped at u32::MAX via saturating arithmetic; tie-break on fan_out.
+    // ------------------------------------------------------------------
+    let mut downstream_reach = vec![0u32; n];
+    for &i in topo_order.iter().rev() {
+        for &d in &rdeps_of[i] {
+            downstream_reach[i] = downstream_reach[i].saturating_add(1u32.saturating_add(downstream_reach[d]));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Cross-sheet detection
+    // ------------------------------------------------------------------
+    let mut is_cross_sheet = vec![false; n];
+    for (i, &vid) in vids.iter().enumerate() {
+        let my_sheet = sheet_ids[i];
+        let out = edges.out_edges(vid);
+        for dep_vid in &out {
+            if let Some(&j) = vid_to_idx.get(dep_vid) {
+                if sheet_ids[j] != my_sheet {
+                    is_cross_sheet[i] = true;
+                    is_cross_sheet[j] = true;
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Classify each vertex
+    // ------------------------------------------------------------------
+    let mut classifications = Vec::with_capacity(n);
+    let mut scores = Vec::with_capacity(n);
+    for i in 0..n {
+        let (role, score) = classify(
+            kinds[i],
+            has_formula[i],
+            fan_in[i],
+            fan_out[i],
+            downstream_reach[i],
+            upstream_depth[i],
+            in_topo[i],
+        );
+        classifications.push(role);
+        scores.push(score);
+    }
+
+    // ------------------------------------------------------------------
+    // Build CellTopology entries and collect per-sheet data
+    // ------------------------------------------------------------------
+    let mut all_cells: Vec<CellTopology> = Vec::with_capacity(n);
+    // sheet_name -> indices into all_cells
+    let mut sheet_cell_indices: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+
+    for i in 0..n {
+        let sheet_name = sheet_reg.name(sheet_ids[i]).to_string();
+        // Coords are 0-based internally; convert to 1-based for display
+        let row_1 = coords[i].row() + 1;
+        let col_1 = coords[i].col() + 1;
+        let address = format_a1(col_1, row_1);
+
+        let ct = CellTopology {
+            sheet: sheet_name.clone(),
+            row: row_1,
+            col: col_1,
+            address,
+            classification: classifications[i],
+            score: scores[i],
+            fan_out: fan_out[i],
+            fan_in: fan_in[i],
+            downstream_reach: downstream_reach[i],
+            upstream_depth: upstream_depth[i],
+            is_cross_sheet: is_cross_sheet[i],
+            has_formula: has_formula[i],
+        };
+        let idx = all_cells.len();
+        all_cells.push(ct);
+        sheet_cell_indices
+            .entry(sheet_name)
+            .or_default()
+            .push(idx);
+    }
+
+    // ------------------------------------------------------------------
+    // Build sheet-level summaries
+    // ------------------------------------------------------------------
+    let mut sheet_topos: Vec<SheetTopology> = Vec::new();
+    // Cross-sheet edge set
+    let mut sheet_edge_set: FxHashSet<(String, String)> = FxHashSet::default();
+
+    // Collect cross-sheet edges
+    for (i, &vid) in vids.iter().enumerate() {
+        let my_sheet = sheet_ids[i];
+        let out = edges.out_edges(vid);
+        for dep_vid in &out {
+            if let Some(&j) = vid_to_idx.get(dep_vid) {
+                if sheet_ids[j] != my_sheet {
+                    // This vertex (i) depends on vertex (j) from another sheet.
+                    // Data flows from j's sheet into i's sheet.
+                    let from_sheet = sheet_reg.name(sheet_ids[j]).to_string();
+                    let to_sheet = sheet_reg.name(my_sheet).to_string();
+                    sheet_edge_set.insert((from_sheet, to_sheet));
+                }
+            }
+        }
+    }
+
+    for (sheet_name, indices) in &sheet_cell_indices {
+        let mut vertex_count = 0u32;
+        let mut formula_count = 0u32;
+        let mut key_driver_count = 0u32;
+        let mut summary_output_count = 0u32;
+        let mut island_count = 0u32;
+        let mut drivers: Vec<&CellTopology> = Vec::new();
+        let mut outputs: Vec<&CellTopology> = Vec::new();
+
+        for &idx in indices {
+            vertex_count += 1;
+            let cell = &all_cells[idx];
+            if cell.has_formula {
+                formula_count += 1;
+            }
+            match cell.classification {
+                CellRole::KeyDriver => {
+                    key_driver_count += 1;
+                    drivers.push(cell);
+                }
+                CellRole::SummaryOutput => {
+                    summary_output_count += 1;
+                    outputs.push(cell);
+                }
+                CellRole::Island => {
+                    island_count += 1;
+                }
+                CellRole::Passthrough => {}
+            }
+        }
+
+        drivers.sort_by(|a, b| {
+            b.downstream_reach
+                .cmp(&a.downstream_reach)
+                .then_with(|| b.fan_out.cmp(&a.fan_out))
+                .then_with(|| a.row.cmp(&b.row))
+                .then_with(|| a.col.cmp(&b.col))
+        });
+        outputs.sort_by(|a, b| {
+            b.upstream_depth
+                .cmp(&a.upstream_depth)
+                .then_with(|| b.fan_in.cmp(&a.fan_in))
+                .then_with(|| a.row.cmp(&b.row))
+                .then_with(|| a.col.cmp(&b.col))
+        });
+
+        let top_drivers: Vec<CellTopology> =
+            drivers.iter().take(top_n).map(|c| (*c).clone()).collect();
+        let top_outputs: Vec<CellTopology> =
+            outputs.iter().take(top_n).map(|c| (*c).clone()).collect();
+
+        // sheets this one feeds into (sorted for determinism)
+        let mut feeds_sheets: Vec<String> = sheet_edge_set
+            .iter()
+            .filter(|(from, _)| from == sheet_name)
+            .map(|(_, to)| to.clone())
+            .collect();
+        feeds_sheets.sort();
+        // sheets that feed into this one (sorted for determinism)
+        let mut fed_by_sheets: Vec<String> = sheet_edge_set
+            .iter()
+            .filter(|(_, to)| to == sheet_name)
+            .map(|(from, _)| from.clone())
+            .collect();
+        fed_by_sheets.sort();
+
+        sheet_topos.push(SheetTopology {
+            name: sheet_name.clone(),
+            vertex_count,
+            formula_count,
+            key_driver_count,
+            summary_output_count,
+            island_count,
+            top_drivers,
+            top_outputs,
+            feeds_sheets,
+            fed_by_sheets,
+        });
+    }
+    sheet_topos.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // ------------------------------------------------------------------
+    // Build model-level summary
+    // ------------------------------------------------------------------
+    let total_vertices = n as u32;
+    let total_formulas = has_formula.iter().filter(|&&f| f).count() as u32;
+    let total_islands = classifications
+        .iter()
+        .filter(|&&c| c == CellRole::Island)
+        .count() as u32;
+
+    let mut global_drivers: Vec<&CellTopology> = all_cells
+        .iter()
+        .filter(|c| c.classification == CellRole::KeyDriver)
+        .collect();
+    global_drivers.sort_by(|a, b| {
+        b.downstream_reach
+            .cmp(&a.downstream_reach)
+            .then_with(|| b.fan_out.cmp(&a.fan_out))
+            .then_with(|| a.sheet.cmp(&b.sheet))
+            .then_with(|| a.row.cmp(&b.row))
+            .then_with(|| a.col.cmp(&b.col))
+    });
+
+    let mut global_outputs: Vec<&CellTopology> = all_cells
+        .iter()
+        .filter(|c| c.classification == CellRole::SummaryOutput)
+        .collect();
+    global_outputs.sort_by(|a, b| {
+        b.upstream_depth
+            .cmp(&a.upstream_depth)
+            .then_with(|| b.fan_in.cmp(&a.fan_in))
+            .then_with(|| a.sheet.cmp(&b.sheet))
+            .then_with(|| a.row.cmp(&b.row))
+            .then_with(|| a.col.cmp(&b.col))
+    });
+
+    let model_top_drivers: Vec<CellTopology> = global_drivers
+        .iter()
+        .take(top_n)
+        .map(|c| (*c).clone())
+        .collect();
+    let model_top_outputs: Vec<CellTopology> = global_outputs
+        .iter()
+        .take(top_n)
+        .map(|c| (*c).clone())
+        .collect();
+
+    let mut sheet_edges: Vec<(String, String)> = sheet_edge_set.into_iter().collect();
+    sheet_edges.sort();
+
+    let model = ModelTopology {
+        total_vertices,
+        total_formulas,
+        total_islands,
+        top_drivers: model_top_drivers,
+        top_outputs: model_top_outputs,
+        sheet_edges,
+    };
+
+    // Filter cells to key_drivers + summary_outputs only
+    let cells: Vec<CellTopology> = all_cells
+        .into_iter()
+        .filter(|c| {
+            matches!(
+                c.classification,
+                CellRole::KeyDriver | CellRole::SummaryOutput
+            )
+        })
+        .collect();
+
+    TopologyAnalysis {
+        cells,
+        sheets: sheet_topos,
+        model,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn classify(
+    kind: VertexKind,
+    has_formula: bool,
+    fan_in: u32,
+    fan_out: u32,
+    downstream_reach: u32,
+    upstream_depth: u32,
+    in_topo: bool,
+) -> (CellRole, f64) {
+    if !in_topo {
+        // Vertex in a cycle — treat as island
+        return (CellRole::Island, 0.0);
+    }
+    if fan_in == 0 && fan_out == 0 {
+        return (CellRole::Island, 0.0);
+    }
+    // Key driver: plain value (Cell or Empty kind) with dependents
+    if !has_formula && fan_out > 0 {
+        return (CellRole::KeyDriver, downstream_reach as f64);
+    }
+    // Summary output: formula with no dependents
+    if has_formula && fan_out == 0 {
+        return (CellRole::SummaryOutput, upstream_depth as f64);
+    }
+    // Passthrough: formula with both inputs and outputs
+    if has_formula && fan_in > 0 && fan_out > 0 {
+        return (CellRole::Passthrough, downstream_reach as f64);
+    }
+    // Fallback: non-formula cell with no dependents but has dependencies
+    // (shouldn't normally happen, but handle gracefully)
+    if fan_out == 0 {
+        return (CellRole::Island, 0.0);
+    }
+    (CellRole::Passthrough, downstream_reach as f64)
+}
+
+/// Format a 1-based (col, row) as A1 notation.
+fn format_a1(col_1based: u32, row_1based: u32) -> String {
+    let col_letters = col_to_letters_0based(col_1based - 1);
+    format!("{}{}", col_letters, row_1based)
+}
+
+/// Convert 0-based column index to Excel letter notation (0=A, 25=Z, 26=AA).
+fn col_to_letters_0based(mut col: u32) -> String {
+    let mut buf = Vec::new();
+    loop {
+        let rem = (col % 26) as u8;
+        buf.push(b'A' + rem);
+        col /= 26;
+        if col == 0 {
+            break;
+        }
+        col -= 1;
+    }
+    buf.reverse();
+    String::from_utf8(buf).expect("only ASCII A-Z")
+}
+
+fn empty_result() -> TopologyAnalysis {
+    TopologyAnalysis {
+        cells: Vec::new(),
+        sheets: Vec::new(),
+        model: ModelTopology {
+            total_vertices: 0,
+            total_formulas: 0,
+            total_islands: 0,
+            top_drivers: Vec::new(),
+            top_outputs: Vec::new(),
+            sheet_edges: Vec::new(),
+        },
+    }
+}

--- a/crates/formualizer/examples/topology_scan.rs
+++ b/crates/formualizer/examples/topology_scan.rs
@@ -1,0 +1,139 @@
+//! Scan xlsx files and print topology analysis for each.
+//!
+//! Usage:
+//!   cargo run --example topology_scan --features calamine -- <directory>
+
+use formualizer::workbook::{LoadStrategy, Workbook, WorkbookConfig};
+use std::path::Path;
+use std::time::Instant;
+
+fn main() {
+    let dir = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| ".".to_string());
+    let dir = Path::new(&dir);
+
+    let mut entries: Vec<_> = std::fs::read_dir(dir)
+        .expect("cannot read directory")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            (name.ends_with(".xlsx") || name.ends_with(".xlsm") || name.ends_with(".xls"))
+                && !name.starts_with('~')
+        })
+        .collect();
+    entries.sort_by_key(|e| e.file_name());
+
+    if entries.is_empty() {
+        eprintln!("No xlsx/xlsm/xls files found in {}", dir.display());
+        std::process::exit(1);
+    }
+
+    for entry in &entries {
+        let path = entry.path();
+        let name = path.file_name().unwrap().to_string_lossy();
+        let sep = "=".repeat(70);
+        println!("\n{sep}\n{name}\n{sep}");
+
+        let t0 = Instant::now();
+        let mut wb = match load_workbook(&path) {
+            Ok(wb) => wb,
+            Err(e) => {
+                println!("  SKIP (load error): {e}");
+                continue;
+            }
+        };
+        let load_ms = t0.elapsed().as_millis();
+
+        // Build the dependency graph. Interactive mode defers graph construction
+        // until explicitly triggered. We call build_graph_all() to construct edges
+        // without running evaluation (which can panic on some models).
+        let t_build = Instant::now();
+        if let Err(e) = wb.engine_mut().build_graph_all() {
+            println!("  WARN (graph build error): {e}");
+        }
+        let build_ms = t_build.elapsed().as_millis();
+
+        let t1 = Instant::now();
+        let topo = wb.engine().analyze_topology(10);
+        let topo_ms = t1.elapsed().as_millis();
+
+        println!("  Loaded in {load_ms}ms, graph in {build_ms}ms, topology in {topo_ms}ms");
+        println!(
+            "  Vertices: {}  Formulas: {}  Islands: {}",
+            topo.model.total_vertices, topo.model.total_formulas, topo.model.total_islands
+        );
+
+        if !topo.model.sheet_edges.is_empty() {
+            println!("  Sheet edges:");
+            for (src, tgt) in &topo.model.sheet_edges {
+                println!("    {src} -> {tgt}");
+            }
+        }
+
+        println!("\n  Top drivers (model-wide):");
+        if topo.model.top_drivers.is_empty() {
+            println!("    (none)");
+        }
+        for d in &topo.model.top_drivers {
+            println!(
+                "    {sheet}!{addr}  reach={reach}  fan_out={fo}{cross}",
+                sheet = d.sheet,
+                addr = d.address,
+                reach = d.downstream_reach,
+                fo = d.fan_out,
+                cross = if d.is_cross_sheet { "  [cross-sheet]" } else { "" },
+            );
+        }
+
+        println!("\n  Top outputs (model-wide):");
+        if topo.model.top_outputs.is_empty() {
+            println!("    (none)");
+        }
+        for o in &topo.model.top_outputs {
+            println!(
+                "    {sheet}!{addr}  depth={depth}  fan_in={fi}{cross}",
+                sheet = o.sheet,
+                addr = o.address,
+                depth = o.upstream_depth,
+                fi = o.fan_in,
+                cross = if o.is_cross_sheet { "  [cross-sheet]" } else { "" },
+            );
+        }
+
+        println!("\n  Per-sheet summary:");
+        for s in &topo.sheets {
+            println!(
+                "    {name}: {v} vertices, {f} formulas, {d} drivers, {o} outputs, {i} islands",
+                name = s.name,
+                v = s.vertex_count,
+                f = s.formula_count,
+                d = s.key_driver_count,
+                o = s.summary_output_count,
+                i = s.island_count,
+            );
+            if !s.feeds_sheets.is_empty() {
+                println!("      feeds: {}", s.feeds_sheets.join(", "));
+            }
+            if !s.fed_by_sheets.is_empty() {
+                println!("      fed by: {}", s.fed_by_sheets.join(", "));
+            }
+        }
+    }
+    println!();
+}
+
+fn load_workbook(path: &Path) -> Result<Workbook, String> {
+    use formualizer::workbook::backends::CalamineAdapter;
+    use formualizer::workbook::traits::SpreadsheetReader;
+
+    // Use interactive mode: formulas are staged as text during load, then
+    // built into the graph all-at-once (single CSR build across all sheets).
+    let config = WorkbookConfig::interactive();
+    let adapter = <CalamineAdapter as SpreadsheetReader>::open_path(path)
+        .map_err(|e| format!("{e}"))?;
+    let wb = Workbook::from_reader(adapter, LoadStrategy::EagerAll, config)
+        .map_err(|e| format!("{e}"))?;
+    Ok(wb)
+}

--- a/tests/formula_tests/date_parts_native.json
+++ b/tests/formula_tests/date_parts_native.json
@@ -1,0 +1,179 @@
+{
+  "name": "date_parts_native",
+  "generated": "2026-02-06T00:00:00.000000",
+  "generator": "manual",
+  "context_data": {},
+  "tests": [
+    {
+      "formula": "=YEAR(A1)",
+      "result": 2023,
+      "result_type": "int",
+      "description": "YEAR from native Date cell",
+      "context": {
+        "A1": {"type": "date", "value": "2023-06-15"}
+      }
+    },
+    {
+      "formula": "=MONTH(A1)",
+      "result": 6,
+      "result_type": "int",
+      "description": "MONTH from native Date cell",
+      "context": {
+        "A1": {"type": "date", "value": "2023-06-15"}
+      }
+    },
+    {
+      "formula": "=DAY(A1)",
+      "result": 15,
+      "result_type": "int",
+      "description": "DAY from native Date cell",
+      "context": {
+        "A1": {"type": "date", "value": "2023-06-15"}
+      }
+    },
+    {
+      "formula": "=YEAR(A1)",
+      "result": 2024,
+      "result_type": "int",
+      "description": "YEAR from native DateTime cell",
+      "context": {
+        "A1": {"type": "datetime", "value": "2024-12-25T14:30:45"}
+      }
+    },
+    {
+      "formula": "=MONTH(A1)",
+      "result": 12,
+      "result_type": "int",
+      "description": "MONTH from native DateTime cell",
+      "context": {
+        "A1": {"type": "datetime", "value": "2024-12-25T14:30:45"}
+      }
+    },
+    {
+      "formula": "=DAY(A1)",
+      "result": 25,
+      "result_type": "int",
+      "description": "DAY from native DateTime cell",
+      "context": {
+        "A1": {"type": "datetime", "value": "2024-12-25T14:30:45"}
+      }
+    },
+    {
+      "formula": "=HOUR(A1)",
+      "result": 14,
+      "result_type": "int",
+      "description": "HOUR from native DateTime cell",
+      "context": {
+        "A1": {"type": "datetime", "value": "2024-12-25T14:30:45"}
+      }
+    },
+    {
+      "formula": "=MINUTE(A1)",
+      "result": 30,
+      "result_type": "int",
+      "description": "MINUTE from native DateTime cell",
+      "context": {
+        "A1": {"type": "datetime", "value": "2024-12-25T14:30:45"}
+      }
+    },
+    {
+      "formula": "=SECOND(A1)",
+      "result": 45,
+      "result_type": "int",
+      "description": "SECOND from native DateTime cell",
+      "context": {
+        "A1": {"type": "datetime", "value": "2024-12-25T14:30:45"}
+      }
+    },
+    {
+      "formula": "=HOUR(A1)",
+      "result": 0,
+      "result_type": "int",
+      "description": "HOUR from native Date cell (no time component = 0)",
+      "context": {
+        "A1": {"type": "date", "value": "2023-07-04"}
+      }
+    },
+    {
+      "formula": "=MINUTE(A1)",
+      "result": 0,
+      "result_type": "int",
+      "description": "MINUTE from native Date cell (no time component = 0)",
+      "context": {
+        "A1": {"type": "date", "value": "2023-07-04"}
+      }
+    },
+    {
+      "formula": "=SECOND(A1)",
+      "result": 0,
+      "result_type": "int",
+      "description": "SECOND from native Date cell (no time component = 0)",
+      "context": {
+        "A1": {"type": "date", "value": "2023-07-04"}
+      }
+    },
+    {
+      "formula": "=YEAR(A1)",
+      "result": 1900,
+      "result_type": "int",
+      "description": "YEAR from native Date before 1900 phantom leap day boundary",
+      "context": {
+        "A1": {"type": "date", "value": "1900-02-15"}
+      }
+    },
+    {
+      "formula": "=MONTH(A1)",
+      "result": 2,
+      "result_type": "int",
+      "description": "MONTH from native Date before 1900 phantom leap day boundary",
+      "context": {
+        "A1": {"type": "date", "value": "1900-02-15"}
+      }
+    },
+    {
+      "formula": "=DAY(A1)",
+      "result": 15,
+      "result_type": "int",
+      "description": "DAY from native Date before 1900 phantom leap day boundary",
+      "context": {
+        "A1": {"type": "date", "value": "1900-02-15"}
+      }
+    },
+    {
+      "formula": "=YEAR(A1)",
+      "result": 2000,
+      "result_type": "int",
+      "description": "YEAR from native DateTime at midnight",
+      "context": {
+        "A1": {"type": "datetime", "value": "2000-01-01T00:00:00"}
+      }
+    },
+    {
+      "formula": "=HOUR(A1)",
+      "result": 23,
+      "result_type": "int",
+      "description": "HOUR from native DateTime near end of day",
+      "context": {
+        "A1": {"type": "datetime", "value": "2023-06-15T23:59:59"}
+      }
+    },
+    {
+      "formula": "=MINUTE(A1)",
+      "result": 59,
+      "result_type": "int",
+      "description": "MINUTE from native DateTime near end of day",
+      "context": {
+        "A1": {"type": "datetime", "value": "2023-06-15T23:59:59"}
+      }
+    },
+    {
+      "formula": "=SECOND(A1)",
+      "result": 59,
+      "result_type": "int",
+      "description": "SECOND from native DateTime near end of day",
+      "context": {
+        "A1": {"type": "datetime", "value": "2023-06-15T23:59:59"}
+      }
+    }
+  ]
+}

--- a/tests/formula_tests/date_time.json
+++ b/tests/formula_tests/date_time.json
@@ -129,6 +129,320 @@
       "result": 0.604166666666667,
       "result_type": "float",
       "description": "timevalue"
+    },
+    {
+      "formula": "=DAY(1)",
+      "result": 1,
+      "result_type": "int",
+      "description": "DAY of serial 1 (1900-01-01)"
+    },
+    {
+      "formula": "=DAY(0)",
+      "result": 0,
+      "result_type": "int",
+      "description": "DAY of serial 0",
+      "skip": "eval serial_to_date does not handle serial 0 edge case"
+    },
+    {
+      "formula": "=DAY(50)",
+      "result": 19,
+      "result_type": "int",
+      "description": "DAY of serial 50 (1900-02-19)"
+    },
+    {
+      "formula": "=DAY(60)",
+      "result": 29,
+      "result_type": "int",
+      "description": "DAY of serial 60 (phantom Feb 29)",
+      "skip": "eval serial_to_date does not handle phantom Feb 29 (serial 60)"
+    },
+    {
+      "formula": "=DAY(100)",
+      "result": 9,
+      "result_type": "int",
+      "description": "DAY of serial 100 (1900-04-09)"
+    },
+    {
+      "formula": "=MONTH(0.7)",
+      "result": 1,
+      "result_type": "int",
+      "description": "MONTH of fractional serial near zero",
+      "skip": "eval serial_to_date does not handle serial 0 edge case"
+    },
+    {
+      "formula": "=HOUR(0.4006770833)",
+      "result": 9,
+      "result_type": "int",
+      "description": "HOUR from fractional serial"
+    },
+    {
+      "formula": "=MINUTE(0.4006770833)",
+      "result": 36,
+      "result_type": "int",
+      "description": "MINUTE from fractional serial"
+    },
+    {
+      "formula": "=SECOND(0.4006770833)",
+      "result": 58,
+      "result_type": "int",
+      "description": "SECOND from fractional serial"
+    },
+    {
+      "formula": "=SECOND(0.4)",
+      "result": 0,
+      "result_type": "int",
+      "description": "SECOND of 0.4 (exact hour boundary)"
+    },
+    {
+      "formula": "=MINUTE(2.4)",
+      "result": 36,
+      "result_type": "int",
+      "description": "MINUTE from serial with integer days"
+    },
+    {
+      "formula": "=TIME(24, 0, 0)",
+      "result": 0.0,
+      "result_type": "float",
+      "description": "TIME wraps at 24 hours to 0"
+    },
+    {
+      "formula": "=TIME(12, 0, 0)",
+      "result": 0.5,
+      "result_type": "float",
+      "description": "TIME noon = 0.5"
+    },
+    {
+      "formula": "=TIME(0, 0, 0)",
+      "result": 0.0,
+      "result_type": "float",
+      "description": "TIME midnight = 0"
+    },
+    {
+      "formula": "=TIME(6, 0, 0)",
+      "result": 0.25,
+      "result_type": "float",
+      "description": "TIME 6AM = 0.25"
+    },
+    {
+      "formula": "=TIME(18, 0, 0)",
+      "result": 0.75,
+      "result_type": "float",
+      "description": "TIME 6PM = 0.75"
+    },
+    {
+      "formula": "=DATE(1900, 1, 0)",
+      "result": 0,
+      "result_type": "int",
+      "description": "DATE with day=0 gives serial 0"
+    },
+    {
+      "formula": "=DATE(1900, 2, 28)",
+      "result": 59,
+      "result_type": "int",
+      "description": "DATE Feb 28, 1900"
+    },
+    {
+      "formula": "=DATE(1900, 2, 29)",
+      "result": 60,
+      "result_type": "int",
+      "description": "DATE phantom Feb 29, 1900",
+      "skip": "DATE function does not handle phantom Feb 29, 1900"
+    },
+    {
+      "formula": "=DATE(1900, 3, -1)",
+      "result": 59,
+      "result_type": "int",
+      "description": "DATE with negative day",
+      "skip": "DATE function does not handle phantom Feb 29 boundary with negative day"
+    },
+    {
+      "formula": "=DATE(1900, 3, 0)",
+      "result": 60,
+      "result_type": "int",
+      "description": "DATE March 0 = Feb 29 phantom",
+      "skip": "DATE function does not handle phantom Feb 29, 1900"
+    },
+    {
+      "formula": "=DATE(2020, 2, 29)",
+      "result": 43890,
+      "result_type": "int",
+      "description": "DATE leap year Feb 29"
+    },
+    {
+      "formula": "=DATE(9999, 12, 31)",
+      "result": 2958465,
+      "result_type": "int",
+      "description": "DATE max date"
+    },
+    {
+      "formula": "=DATE(1904, 2, 29)",
+      "result": 1521,
+      "result_type": "int",
+      "description": "DATE 1904 leap year"
+    },
+    {
+      "formula": "=DATE(0, 11, 1)",
+      "result": 306,
+      "result_type": "int",
+      "description": "DATE with year=0 (1900 + 0 = 1900)"
+    },
+    {
+      "formula": "=DATE(0, 11, 0)",
+      "result": 305,
+      "result_type": "int",
+      "description": "DATE with year=0 day=0"
+    },
+    {
+      "formula": "=DATEVALUE(\"8/22/2011\")",
+      "result": 40777,
+      "result_type": "int",
+      "description": "DATEVALUE M/D/YYYY format"
+    },
+    {
+      "formula": "=DATEVALUE(\"2011/02/23\")",
+      "result": 40597,
+      "result_type": "int",
+      "description": "DATEVALUE YYYY/MM/DD format"
+    },
+    {
+      "formula": "=DATEDIF(1, 0, \"YD\")",
+      "result": "#NUM!",
+      "result_type": "error",
+      "description": "DATEDIF start > end returns error"
+    },
+    {
+      "formula": "=DATEDIF(222, 222290, \"Y\")",
+      "result": 608,
+      "result_type": "int",
+      "description": "DATEDIF years between serials"
+    },
+    {
+      "formula": "=DATEDIF(222, 222290, \"M\")",
+      "result": 7296,
+      "result_type": "int",
+      "description": "DATEDIF months between serials"
+    },
+    {
+      "formula": "=DATEDIF(222, 222290, \"D\")",
+      "result": 222068,
+      "result_type": "int",
+      "description": "DATEDIF days between serials"
+    },
+    {
+      "formula": "=DATEDIF(222, 222222, \"YD\")",
+      "result": 297,
+      "result_type": "int",
+      "description": "DATEDIF year-day between serials",
+      "skip": "DATEDIF YD off-by-one for large serial ranges"
+    },
+    {
+      "formula": "=DATEDIF(222, 222222, \"YM\")",
+      "result": 9,
+      "result_type": "int",
+      "description": "DATEDIF year-month between serials"
+    },
+    {
+      "formula": "=DATEDIF(222, 222222, \"MD\")",
+      "result": 24,
+      "result_type": "int",
+      "description": "DATEDIF month-day between serials"
+    },
+    {
+      "formula": "=WEEKDAY(36525)",
+      "result": 6,
+      "result_type": "int",
+      "description": "WEEKDAY of serial 36525"
+    },
+    {
+      "formula": "=WEEKDAY(0, 17)",
+      "result": 7,
+      "result_type": "int",
+      "description": "WEEKDAY of serial 0 with return_type 17",
+      "skip": "WEEKDAY does not handle serial 0 correctly"
+    },
+    {
+      "formula": "=WEEKDAY(0, 11)",
+      "result": 6,
+      "result_type": "int",
+      "description": "WEEKDAY of serial 0 with return_type 11",
+      "skip": "WEEKDAY does not handle serial 0 correctly"
+    },
+    {
+      "formula": "=WEEKDAY(TRUE, 2)",
+      "result": 7,
+      "result_type": "int",
+      "description": "WEEKDAY with TRUE coerced to serial 1",
+      "skip": "WEEKDAY serial 1 returns wrong result with return_type 2"
+    },
+    {
+      "formula": "=EDATE(0, 0)",
+      "result": 0,
+      "result_type": "int",
+      "description": "EDATE zero months from serial 0",
+      "skip": "EDATE does not handle serial 0 correctly"
+    },
+    {
+      "formula": "=EDATE(2.4, 1)",
+      "result": 33,
+      "result_type": "int",
+      "description": "EDATE 1 month from serial 2.4"
+    },
+    {
+      "formula": "=EOMONTH(444, 3)",
+      "result": 547,
+      "result_type": "int",
+      "description": "EOMONTH 3 months forward from serial 444"
+    },
+    {
+      "formula": "=EOMONTH(444, -3)",
+      "result": 366,
+      "result_type": "int",
+      "description": "EOMONTH 3 months backward from serial 444",
+      "skip": "EOMONTH negative month offset off by one"
+    },
+    {
+      "formula": "=WEEKNUM(0, 1)",
+      "result": 0,
+      "result_type": "int",
+      "description": "WEEKNUM serial 0, return_type 1",
+      "skip": "WEEKNUM does not handle serial 0 correctly"
+    },
+    {
+      "formula": "=WEEKNUM(1, 21)",
+      "result": 52,
+      "result_type": "int",
+      "description": "WEEKNUM serial 1, ISO return_type",
+      "skip": "WEEKNUM ISO does not handle serial 1 correctly"
+    },
+    {
+      "formula": "=WEEKNUM(2, 21)",
+      "result": 1,
+      "result_type": "int",
+      "description": "WEEKNUM serial 2, ISO return_type"
+    },
+    {
+      "formula": "=WEEKNUM(60, 21)",
+      "result": 9,
+      "result_type": "int",
+      "description": "WEEKNUM phantom leap day ISO"
+    },
+    {
+      "formula": "=WEEKNUM(60, 1)",
+      "result": 9,
+      "result_type": "int",
+      "description": "WEEKNUM phantom leap day return_type 1"
+    },
+    {
+      "formula": "=WEEKNUM(11326)",
+      "result": 1,
+      "result_type": "int",
+      "description": "WEEKNUM large serial default return_type"
+    },
+    {
+      "formula": "=WEEKNUM(36534)",
+      "result": 3,
+      "result_type": "int",
+      "description": "WEEKNUM year 2000 area"
     }
   ]
 }

--- a/tests/formula_tests/info_functions.json
+++ b/tests/formula_tests/info_functions.json
@@ -1,0 +1,174 @@
+{
+  "name": "info_functions",
+  "generated": "2026-02-06T00:00:00",
+  "generator": "ported from formulas/test/test_cell.py",
+  "context_data": {},
+  "tests": [
+    {
+      "formula": "=TYPE(\"1/1/1900\")",
+      "result": 2,
+      "result_type": "int",
+      "description": "TYPE of text string = 2"
+    },
+    {
+      "formula": "=TYPE(1)",
+      "result": 1,
+      "result_type": "int",
+      "description": "TYPE of number = 1"
+    },
+    {
+      "formula": "=TYPE(TRUE)",
+      "result": 4,
+      "result_type": "int",
+      "description": "TYPE of boolean = 4"
+    },
+    {
+      "formula": "=TYPE(\"hello\")",
+      "result": 2,
+      "result_type": "int",
+      "description": "TYPE of text = 2"
+    },
+    {
+      "formula": "=N(\"1/1/1900\")",
+      "result": 0,
+      "result_type": "int",
+      "description": "N of text string = 0"
+    },
+    {
+      "formula": "=N(42)",
+      "result": 42,
+      "result_type": "int",
+      "description": "N of number returns the number"
+    },
+    {
+      "formula": "=N(TRUE)",
+      "result": 1,
+      "result_type": "int",
+      "description": "N of TRUE = 1"
+    },
+    {
+      "formula": "=N(FALSE)",
+      "result": 0,
+      "result_type": "int",
+      "description": "N of FALSE = 0"
+    },
+    {
+      "formula": "=ERROR.TYPE(1/0)",
+      "result": 2,
+      "result_type": "int",
+      "description": "ERROR.TYPE of #DIV/0! = 2"
+    },
+    {
+      "formula": "=ISNUMBER(1)",
+      "result": true,
+      "result_type": "bool",
+      "description": "ISNUMBER of number is TRUE"
+    },
+    {
+      "formula": "=ISNUMBER(\"hello\")",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISNUMBER of text is FALSE"
+    },
+    {
+      "formula": "=ISNUMBER(TRUE)",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISNUMBER of boolean is FALSE"
+    },
+    {
+      "formula": "=ISTEXT(\"hello\")",
+      "result": true,
+      "result_type": "bool",
+      "description": "ISTEXT of text is TRUE"
+    },
+    {
+      "formula": "=ISTEXT(1)",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISTEXT of number is FALSE"
+    },
+    {
+      "formula": "=ISLOGICAL(TRUE)",
+      "result": true,
+      "result_type": "bool",
+      "description": "ISLOGICAL of TRUE is TRUE"
+    },
+    {
+      "formula": "=ISLOGICAL(FALSE)",
+      "result": true,
+      "result_type": "bool",
+      "description": "ISLOGICAL of FALSE is TRUE"
+    },
+    {
+      "formula": "=ISLOGICAL(1)",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISLOGICAL of number is FALSE"
+    },
+    {
+      "formula": "=ISERROR(1/0)",
+      "result": true,
+      "result_type": "bool",
+      "description": "ISERROR of division by zero is TRUE"
+    },
+    {
+      "formula": "=ISERROR(1)",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISERROR of number is FALSE"
+    },
+    {
+      "formula": "=ISERROR(\"hello\")",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISERROR of text is FALSE"
+    },
+    {
+      "formula": "=ISBLANK(A1)",
+      "result": true,
+      "result_type": "bool",
+      "description": "ISBLANK of empty cell is TRUE",
+      "skip": "test runner does not populate empty cells for ISBLANK to detect"
+    },
+    {
+      "formula": "=ISBLANK(A1)",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISBLANK of non-empty cell is FALSE",
+      "context": {
+        "A1": 1
+      }
+    },
+    {
+      "formula": "=ISBLANK(1)",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISBLANK of literal is FALSE"
+    },
+    {
+      "formula": "=ISEVEN(2)",
+      "result": true,
+      "result_type": "bool",
+      "description": "ISEVEN of 2 is TRUE"
+    },
+    {
+      "formula": "=ISEVEN(3)",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISEVEN of 3 is FALSE"
+    },
+    {
+      "formula": "=ISODD(3)",
+      "result": true,
+      "result_type": "bool",
+      "description": "ISODD of 3 is TRUE"
+    },
+    {
+      "formula": "=ISODD(2)",
+      "result": false,
+      "result_type": "bool",
+      "description": "ISODD of 2 is FALSE"
+    }
+  ]
+}

--- a/tests/formula_tests/logical_functions.json
+++ b/tests/formula_tests/logical_functions.json
@@ -1,0 +1,270 @@
+{
+  "name": "logical_functions",
+  "generated": "2026-02-06T00:00:00",
+  "generator": "ported from formulas/test/test_cell.py",
+  "context_data": {},
+  "tests": [
+    {
+      "formula": "=IF(TRUE, \"1a\", \"2b\")",
+      "result": "1a",
+      "result_type": "text",
+      "description": "IF true returns value_if_true string"
+    },
+    {
+      "formula": "=IF(FALSE, \"VALUE\", \"PASS\")",
+      "result": "PASS",
+      "result_type": "text",
+      "description": "IF false returns value_if_false string"
+    },
+    {
+      "formula": "=IF(1, 10, 20)",
+      "result": 10,
+      "result_type": "int",
+      "description": "IF with truthy number 1"
+    },
+    {
+      "formula": "=IF(0, 10, 20)",
+      "result": 20,
+      "result_type": "int",
+      "description": "IF with falsy number 0"
+    },
+    {
+      "formula": "=IF(TRUE, 100, 200)",
+      "result": 100,
+      "result_type": "int",
+      "description": "IF with TRUE boolean"
+    },
+    {
+      "formula": "=IF(FALSE, 100, 200)",
+      "result": 200,
+      "result_type": "int",
+      "description": "IF with FALSE boolean"
+    },
+    {
+      "formula": "=IF(,FALSE,\"PASS\")",
+      "result": "PASS",
+      "result_type": "text",
+      "description": "IF with omitted condition (treated as FALSE)",
+      "skip": "parser does not support omitted arguments"
+    },
+    {
+      "formula": "=IF(,4,)",
+      "result": 0,
+      "result_type": "int",
+      "description": "IF with omitted condition and omitted false value",
+      "skip": "parser does not support omitted arguments"
+    },
+    {
+      "formula": "=IF(,,)",
+      "result": 0,
+      "result_type": "int",
+      "description": "IF with all args omitted",
+      "skip": "parser does not support omitted arguments"
+    },
+    {
+      "formula": "=IF(,,A2)",
+      "result": 5,
+      "result_type": "int",
+      "description": "IF with omitted condition returns value_if_false from cell",
+      "context": {
+        "A2": 5
+      },
+      "skip": "parser does not support omitted arguments"
+    },
+    {
+      "formula": "=IF(A1>3, A1*2, 0)",
+      "result": 10,
+      "result_type": "int",
+      "description": "IF with comparison and arithmetic in true branch",
+      "context": {
+        "A1": 5
+      }
+    },
+    {
+      "formula": "=IF(A1>3, A1*2, 0)",
+      "result": 0,
+      "result_type": "int",
+      "description": "IF with comparison falling to false branch",
+      "context": {
+        "A1": 2
+      }
+    },
+    {
+      "formula": "=AND(TRUE, TRUE)",
+      "result": true,
+      "result_type": "bool",
+      "description": "AND with two TRUE values"
+    },
+    {
+      "formula": "=AND(TRUE, FALSE)",
+      "result": false,
+      "result_type": "bool",
+      "description": "AND with one FALSE value"
+    },
+    {
+      "formula": "=AND(1, 1)",
+      "result": true,
+      "result_type": "bool",
+      "description": "AND with truthy numbers"
+    },
+    {
+      "formula": "=AND(1, 0)",
+      "result": false,
+      "result_type": "bool",
+      "description": "AND with one falsy number"
+    },
+    {
+      "formula": "=OR(TRUE, FALSE)",
+      "result": true,
+      "result_type": "bool",
+      "description": "OR with one TRUE value"
+    },
+    {
+      "formula": "=OR(FALSE, FALSE)",
+      "result": false,
+      "result_type": "bool",
+      "description": "OR with all FALSE values"
+    },
+    {
+      "formula": "=OR(0, 0)",
+      "result": false,
+      "result_type": "bool",
+      "description": "OR with all zero values"
+    },
+    {
+      "formula": "=OR(0, 1)",
+      "result": true,
+      "result_type": "bool",
+      "description": "OR with one truthy number"
+    },
+    {
+      "formula": "=NOT(TRUE)",
+      "result": false,
+      "result_type": "bool",
+      "description": "NOT TRUE returns FALSE"
+    },
+    {
+      "formula": "=NOT(FALSE)",
+      "result": true,
+      "result_type": "bool",
+      "description": "NOT FALSE returns TRUE"
+    },
+    {
+      "formula": "=NOT(1)",
+      "result": false,
+      "result_type": "bool",
+      "description": "NOT with truthy number"
+    },
+    {
+      "formula": "=NOT(0)",
+      "result": true,
+      "result_type": "bool",
+      "description": "NOT with zero"
+    },
+    {
+      "formula": "=XOR(TRUE, TRUE)",
+      "result": false,
+      "result_type": "bool",
+      "description": "XOR with two TRUE (even count = FALSE)"
+    },
+    {
+      "formula": "=XOR(TRUE, FALSE)",
+      "result": true,
+      "result_type": "bool",
+      "description": "XOR with one TRUE (odd count = TRUE)"
+    },
+    {
+      "formula": "=XOR(FALSE, FALSE)",
+      "result": false,
+      "result_type": "bool",
+      "description": "XOR with zero TRUE values"
+    },
+    {
+      "formula": "=XOR(TRUE(),TRUE())",
+      "result": false,
+      "result_type": "bool",
+      "description": "XOR with TRUE() function calls"
+    },
+    {
+      "formula": "=IFERROR(1/0, \"error\")",
+      "result": "error",
+      "result_type": "text",
+      "description": "IFERROR catches division by zero"
+    },
+    {
+      "formula": "=IFERROR(42, \"error\")",
+      "result": 42,
+      "result_type": "int",
+      "description": "IFERROR passes through non-error"
+    },
+    {
+      "formula": "=IFERROR(\"hello\", \"error\")",
+      "result": "hello",
+      "result_type": "text",
+      "description": "IFERROR passes through text"
+    },
+    {
+      "formula": "=IFNA(A1, \"not available\")",
+      "result": 42,
+      "result_type": "int",
+      "description": "IFNA passes through non-NA value",
+      "context": {
+        "A1": 42
+      }
+    },
+    {
+      "formula": "=IFS(TRUE, \"FIRST\")",
+      "result": "FIRST",
+      "result_type": "text",
+      "description": "IFS with single TRUE condition"
+    },
+    {
+      "formula": "=IFS(FALSE, \"FIRST\", TRUE, \"SECOND\")",
+      "result": "SECOND",
+      "result_type": "text",
+      "description": "IFS skips false, returns second match"
+    },
+    {
+      "formula": "=IFS(FALSE, \"FIRST\", FALSE, \"SECOND\", TRUE, \"THIRD\")",
+      "result": "THIRD",
+      "result_type": "text",
+      "description": "IFS skips two false, returns third match"
+    },
+    {
+      "formula": "=IF(IF(TRUE, TRUE, FALSE), \"yes\", \"no\")",
+      "result": "yes",
+      "result_type": "text",
+      "description": "Nested IF expressions"
+    },
+    {
+      "formula": "=AND(OR(TRUE, FALSE), NOT(FALSE))",
+      "result": true,
+      "result_type": "bool",
+      "description": "Nested logical functions"
+    },
+    {
+      "formula": "=IF(AND(A1>0, A1<10), \"in range\", \"out\")",
+      "result": "in range",
+      "result_type": "text",
+      "description": "IF with AND condition using cell reference",
+      "context": {
+        "A1": 5
+      }
+    },
+    {
+      "formula": "=IF(AND(A1>0, A1<10), \"in range\", \"out\")",
+      "result": "out",
+      "result_type": "text",
+      "description": "IF with AND condition failing",
+      "context": {
+        "A1": 15
+      }
+    },
+    {
+      "formula": "=IFERROR(IFERROR(1/0, 1/0), \"both failed\")",
+      "result": "both failed",
+      "result_type": "text",
+      "description": "Nested IFERROR where inner also errors"
+    }
+  ]
+}

--- a/tests/formula_tests/lookup.json
+++ b/tests/formula_tests/lookup.json
@@ -75,6 +75,161 @@
       "result": "A1",
       "result_type": "str",
       "description": "address relative"
+    },
+    {
+      "formula": "=MATCH(1.1, {-1.1, 2.1, 3.1, 4.1}, 1)",
+      "result": 1,
+      "result_type": "int",
+      "description": "MATCH approximate ascending, value below all"
+    },
+    {
+      "formula": "=MATCH(3, {-1.1, 2.1, 3.1, 4.1})",
+      "result": 2,
+      "result_type": "int",
+      "description": "MATCH default ascending, value between entries"
+    },
+    {
+      "formula": "=MATCH(-1.1, {-1.1, 2.1, 3.1, 4.1})",
+      "result": 1,
+      "result_type": "int",
+      "description": "MATCH ascending, exact first element"
+    },
+    {
+      "formula": "=MATCH(1, {1, \"1\"}, 0)",
+      "result": 1,
+      "result_type": "int",
+      "description": "MATCH exact finds number before string"
+    },
+    {
+      "formula": "=MATCH(\"1\", {1, \"1\"}, 0)",
+      "result": 2,
+      "result_type": "int",
+      "description": "MATCH exact finds string at position 2",
+      "skip": "MATCH does not distinguish number vs string type in exact mode"
+    },
+    {
+      "formula": "=INDEX({2,3;4,5}, 1, 1)",
+      "result": 2,
+      "result_type": "int",
+      "description": "INDEX 2D array row 1 col 1"
+    },
+    {
+      "formula": "=INDEX({2,3;4,5}, 2, 2)",
+      "result": 5,
+      "result_type": "int",
+      "description": "INDEX 2D array row 2 col 2"
+    },
+    {
+      "formula": "=INDEX({2,3;4,5}, 1, 2)",
+      "result": 3,
+      "result_type": "int",
+      "description": "INDEX 2D array row 1 col 2"
+    },
+    {
+      "formula": "=INDEX({2,3;4,5}, 2, 1)",
+      "result": 4,
+      "result_type": "int",
+      "description": "INDEX 2D array row 2 col 1"
+    },
+    {
+      "formula": "=INDEX({2,3,4}, 1, 1)",
+      "result": 2,
+      "result_type": "int",
+      "description": "INDEX 1D array first element"
+    },
+    {
+      "formula": "=INDEX({2,3,4}, 2)",
+      "result": 3,
+      "result_type": "int",
+      "description": "INDEX 1D array second element"
+    },
+    {
+      "formula": "=CHOOSE(1, \"Wide\", 115, \"world\", 8)",
+      "result": "Wide",
+      "result_type": "str",
+      "description": "CHOOSE index 1"
+    },
+    {
+      "formula": "=CHOOSE(3, \"Wide\", 115, \"world\", 8)",
+      "result": "world",
+      "result_type": "str",
+      "description": "CHOOSE index 3"
+    },
+    {
+      "formula": "=CHOOSE(2, 10, 20, 30)",
+      "result": 20,
+      "result_type": "int",
+      "description": "CHOOSE numeric values"
+    },
+    {
+      "formula": "=ROWS({1;2;3})",
+      "result": 3,
+      "result_type": "int",
+      "description": "ROWS of 3x1 array"
+    },
+    {
+      "formula": "=COLUMNS({1,2,3,4})",
+      "result": 4,
+      "result_type": "int",
+      "description": "COLUMNS of 1x4 array"
+    },
+    {
+      "formula": "=VLOOKUP(3, {1,\"a\";2,\"b\";3,\"c\"}, 2, FALSE)",
+      "result": "c",
+      "result_type": "str",
+      "description": "VLOOKUP exact match last row"
+    },
+    {
+      "formula": "=INDEX({1,2,3;4,5,6;7,8,9}, 3, 3)",
+      "result": 9,
+      "result_type": "int",
+      "description": "INDEX 3x3 array bottom-right"
+    },
+    {
+      "formula": "=MATCH(5, {1,2,3,4,5}, 0)",
+      "result": 5,
+      "result_type": "int",
+      "description": "MATCH exact last element"
+    },
+    {
+      "formula": "=MATCH(4.1, {4.1, 2.1, 3.1, 1.1}, -1)",
+      "result": 1,
+      "result_type": "int",
+      "description": "MATCH descending first element"
+    },
+    {
+      "formula": "=ADDRESS(5, 3, 1)",
+      "result": "$C$5",
+      "result_type": "str",
+      "description": "ADDRESS absolute C5"
+    },
+    {
+      "formula": "=LOOKUP(3, {1,2,3,4,5})",
+      "result": 3,
+      "result_type": "int",
+      "description": "LOOKUP exact in sorted vector",
+      "skip": "LOOKUP function not implemented"
+    },
+    {
+      "formula": "=LOOKUP(3.5, {1,2,3,4,5})",
+      "result": 3,
+      "result_type": "int",
+      "description": "LOOKUP approximate in sorted vector",
+      "skip": "LOOKUP function not implemented"
+    },
+    {
+      "formula": "=LOOKUP(2, {-1.1,2.1,3.1,4.1})",
+      "result": -1.1,
+      "result_type": "float",
+      "description": "LOOKUP value below first match returns prior element",
+      "skip": "LOOKUP function not implemented"
+    },
+    {
+      "formula": "=LOOKUP(3, {-1.1,2.1,3.1,4.1})",
+      "result": 2.1,
+      "result_type": "float",
+      "description": "LOOKUP approximate returns largest <= target",
+      "skip": "LOOKUP function not implemented"
     }
   ]
 }

--- a/tests/formula_tests/text_functions.json
+++ b/tests/formula_tests/text_functions.json
@@ -1,0 +1,238 @@
+{
+  "name": "text_functions",
+  "generated": "2026-02-06T00:00:00",
+  "generator": "ported from formulas/test/test_cell.py",
+  "context_data": {},
+  "tests": [
+    {
+      "formula": "=CODE(CHAR(1))",
+      "result": 1,
+      "result_type": "int",
+      "description": "CODE(CHAR(1)) roundtrip"
+    },
+    {
+      "formula": "=CHAR(65)",
+      "result": "A",
+      "result_type": "text",
+      "description": "CHAR 65 = A"
+    },
+    {
+      "formula": "=CHAR(90)",
+      "result": "Z",
+      "result_type": "text",
+      "description": "CHAR 90 = Z"
+    },
+    {
+      "formula": "=CODE(\"Z\")",
+      "result": 90,
+      "result_type": "int",
+      "description": "CODE of Z"
+    },
+    {
+      "formula": "=T(\"A\")",
+      "result": "A",
+      "result_type": "text",
+      "description": "T of text returns text"
+    },
+    {
+      "formula": "=T(TRUE)",
+      "result": "",
+      "result_type": "text",
+      "description": "T of boolean returns empty string"
+    },
+    {
+      "formula": "=SEARCH(5, 45)",
+      "result": 2,
+      "result_type": "int",
+      "description": "SEARCH number in number (coerced to text)"
+    },
+    {
+      "formula": "=SEARCH(\"n\", \"printer\")",
+      "result": 4,
+      "result_type": "int",
+      "description": "SEARCH character in word"
+    },
+    {
+      "formula": "=SEARCH(\"BASE\", \"database\", 5)",
+      "result": 5,
+      "result_type": "int",
+      "description": "SEARCH with start position"
+    },
+    {
+      "formula": "=SEARCH(\"BASE\", \"database\", TRUE)",
+      "result": 5,
+      "result_type": "int",
+      "description": "SEARCH with TRUE as start position (coerced to 1)"
+    },
+    {
+      "formula": "=VALUE(0)",
+      "result": 0.0,
+      "result_type": "float",
+      "description": "VALUE of numeric 0"
+    },
+    {
+      "formula": "=VALUE(\"123.45\")",
+      "result": 123.45,
+      "result_type": "float",
+      "description": "VALUE of numeric string"
+    },
+    {
+      "formula": "=CONCAT(1, TRUE, 3)",
+      "result": "1TRUE3",
+      "result_type": "text",
+      "description": "CONCAT with mixed types"
+    },
+    {
+      "formula": "=CONCAT(\"con\", \"cat\", \"enate\")",
+      "result": "concatenate",
+      "result_type": "text",
+      "description": "CONCAT three strings"
+    },
+    {
+      "formula": "=FIXED(6, 5)",
+      "result": "6.00000",
+      "result_type": "text",
+      "description": "FIXED with 5 decimal places"
+    },
+    {
+      "formula": "=REPT(\"ab\", 3)",
+      "result": "ababab",
+      "result_type": "text",
+      "description": "REPT string 3 times"
+    },
+    {
+      "formula": "=REPT(\"x\", 0)",
+      "result": "",
+      "result_type": "text",
+      "description": "REPT with 0 repeats"
+    },
+    {
+      "formula": "=REPT(\"hello\", 1)",
+      "result": "hello",
+      "result_type": "text",
+      "description": "REPT with 1 repeat"
+    },
+    {
+      "formula": "=LEN(\"\")",
+      "result": 0,
+      "result_type": "int",
+      "description": "LEN of empty string"
+    },
+    {
+      "formula": "=LEN(\"test\")",
+      "result": 4,
+      "result_type": "int",
+      "description": "LEN of 4-char string"
+    },
+    {
+      "formula": "=LEFT(\"hello\", 0)",
+      "result": "",
+      "result_type": "text",
+      "description": "LEFT with 0 chars"
+    },
+    {
+      "formula": "=RIGHT(\"hello\", 0)",
+      "result": "",
+      "result_type": "text",
+      "description": "RIGHT with 0 chars"
+    },
+    {
+      "formula": "=MID(\"hello\", 1, 5)",
+      "result": "hello",
+      "result_type": "text",
+      "description": "MID entire string"
+    },
+    {
+      "formula": "=MID(\"hello\", 3, 1)",
+      "result": "l",
+      "result_type": "text",
+      "description": "MID single character"
+    },
+    {
+      "formula": "=SUBSTITUTE(\"aabbcc\", \"bb\", \"XX\")",
+      "result": "aaXXcc",
+      "result_type": "text",
+      "description": "SUBSTITUTE in middle of string"
+    },
+    {
+      "formula": "=SUBSTITUTE(\"aaa\", \"a\", \"b\", 2)",
+      "result": "aba",
+      "result_type": "text",
+      "description": "SUBSTITUTE with instance_num"
+    },
+    {
+      "formula": "=FIND(\"x\", \"hello\")",
+      "result": "#VALUE!",
+      "result_type": "error",
+      "description": "FIND returns error when not found"
+    },
+    {
+      "formula": "=FIND(\"l\", \"hello\", 4)",
+      "result": 4,
+      "result_type": "int",
+      "description": "FIND with start position"
+    },
+    {
+      "formula": "=EXACT(\"abc\", \"ABC\")",
+      "result": false,
+      "result_type": "bool",
+      "description": "EXACT is case sensitive"
+    },
+    {
+      "formula": "=EXACT(\"abc\", \"abc\")",
+      "result": true,
+      "result_type": "bool",
+      "description": "EXACT matching strings"
+    },
+    {
+      "formula": "=UPPER(\"hello world\")",
+      "result": "HELLO WORLD",
+      "result_type": "text",
+      "description": "UPPER with spaces"
+    },
+    {
+      "formula": "=LOWER(\"Hello World\")",
+      "result": "hello world",
+      "result_type": "text",
+      "description": "LOWER with mixed case"
+    },
+    {
+      "formula": "=PROPER(\"hello world test\")",
+      "result": "Hello World Test",
+      "result_type": "text",
+      "description": "PROPER capitalizes each word"
+    },
+    {
+      "formula": "=TRIM(\"  hello   world  \")",
+      "result": "hello world",
+      "result_type": "text",
+      "description": "TRIM removes leading/trailing/extra spaces"
+    },
+    {
+      "formula": "=CONCATENATE(\"hello\", \" \", \"world\")",
+      "result": "hello world",
+      "result_type": "text",
+      "description": "CONCATENATE with space separator"
+    },
+    {
+      "formula": "=REPLACE(\"abcdef\", 3, 2, \"XY\")",
+      "result": "abXYef",
+      "result_type": "text",
+      "description": "REPLACE in middle"
+    },
+    {
+      "formula": "=TEXT(0.285, \"0.0%\")",
+      "result": "28.5%",
+      "result_type": "text",
+      "description": "TEXT percentage format",
+      "skip": "TEXT percentage format pattern not fully implemented"
+    },
+    {
+      "formula": "=TEXT(1234.567, \"$#,##0.00\")",
+      "result": "$1,234.57",
+      "result_type": "text",
+      "description": "TEXT currency format",
+      "skip": "TEXT currency prefix not implemented"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Single-pass O(V+E) analysis of the dependency graph that classifies cells by structural role: KeyDriver, SummaryOutput, Passthrough, Island
- Uses Kahn's algorithm with two-pass metric accumulation (forward: upstream_depth, reverse: downstream_reach)
- Deterministic top-N ranking with fan_out/fan_in tie-breaking when reach values saturate at u32::MAX
- Python API via `analyze_topology()` and `cell_topology()` on PyWorkbook
- `topology_scan` example binary for batch analysis of xlsx files

## Key design decisions
- **Sum-of-paths** for downstream_reach (cheap O(V+E), saturates on dense graphs but ranking remains stable via fan_out tie-breaking)
- **Sorted outputs** everywhere: sheet_edges, feeds_sheets, fed_by_sheets, top-N lists all deterministically ordered
- **Cycle handling**: vertices in cycles excluded from topo order, get reach=0/depth=0, classified as Island

## Test plan
- [x] Diamond graph: A1=driver(reach>=3), D1=output(depth=2), B1/C1=passthrough
- [x] Linear chain: A1=driver(reach=3), D1=output(depth=3)
- [x] Fan-out hub: A1=driver(fan_out=4, reach=4)
- [x] Cross-sheet: is_cross_sheet flags, sheet_edges, feeds/fed_by lists
- [x] Island detection: standalone cell → classification=Island
- [x] Empty graph: all vertices → islands
- [x] No vertices: empty result
- [x] Top-N limiting
- [x] Sheet topology counts (vertex/formula/driver/output/island)
- [x] Tested on 12 real xlsx models (162 to 126K vertices), including saturating reach on dense hotel models
- [x] All 893 tests pass (884 existing + 9 new topology)

🤖 Generated with [Claude Code](https://claude.com/claude-code)