### PR TITLE
fix(eval): IF treats empty/blank cells as FALSE

### DIFF
--- a/crates/formualizer-eval/src/builtins/logical.rs
+++ b/crates/formualizer-eval/src/builtins/logical.rs
@@ -265,6 +265,8 @@ impl Function for IfFn {
             LiteralValue::Boolean(b) => b,
             LiteralValue::Number(n) => n != 0.0,
             LiteralValue::Int(i) => i != 0,
+            // Excel treats a blank/empty cell as FALSE
+            LiteralValue::Empty => false,
             _ => {
                 return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
                     ExcelError::new_value().with_message("IF condition must be boolean or number"),


### PR DESCRIPTION
## Summary
- Excel evaluates `=IF(B1, ...)` as FALSE when B1 is empty. Previously the IF function returned `#VALUE!` for empty cell conditions.
- Adds `LiteralValue::Empty => false` to the IF condition match, matching Excel's behavior.
- Note: `=IF("", ...)` (empty string literal) still correctly returns `#VALUE!`.

## Test plan
- [ ] Existing IF tests continue to pass
- [ ] Verify `=IF(empty_cell, "true", "false")` → `"false"`
- [ ] Verify `=IF("", "true", "false")` → `#VALUE!` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)