### PR TITLE
Enforce min_args in dispatch to prevent panics

### DIFF
--- a/crates/formualizer-eval/src/builtins/math/numeric.rs
+++ b/crates/formualizer-eval/src/builtins/math/numeric.rs
@@ -1321,4 +1321,82 @@ mod tests_numeric {
             LiteralValue::Number(4.0)
         );
     }
+
+    // ── Too-few-arguments: must not panic ────────────────────────────────
+    // Excel gates this at the input layer (you can't type =ROUND(5) into a
+    // cell), but programmatically-generated workbooks can contain formulas
+    // with missing arguments. Formualizer must return an error value, not
+    // panic with an index-out-of-bounds.
+
+    #[test]
+    fn round_one_arg_returns_error_not_panic() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(RoundFn));
+        let ctx = interp(&wb);
+        let f = ctx.context.get_function("", "ROUND").unwrap();
+        let n = lit(LiteralValue::Number(2.5));
+        let result = f
+            .dispatch(
+                &[ArgumentHandle::new(&n, &ctx)],
+                &ctx.function_context(None),
+            )
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(result, LiteralValue::Error(_)),
+            "Expected an error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn rounddown_one_arg_returns_error_not_panic() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(RoundDownFn));
+        let ctx = interp(&wb);
+        let f = ctx.context.get_function("", "ROUNDDOWN").unwrap();
+        let n = lit(LiteralValue::Number(1.9));
+        let result = f
+            .dispatch(
+                &[ArgumentHandle::new(&n, &ctx)],
+                &ctx.function_context(None),
+            )
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(result, LiteralValue::Error(_)),
+            "Expected an error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn abs_zero_args_returns_error_not_panic() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(AbsFn));
+        let ctx = interp(&wb);
+        let f = ctx.context.get_function("", "ABS").unwrap();
+        let result = f
+            .dispatch(&[], &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(result, LiteralValue::Error(_)),
+            "Expected an error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn mod_one_arg_returns_error_not_panic() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(ModFn));
+        let ctx = interp(&wb);
+        let f = ctx.context.get_function("", "MOD").unwrap();
+        let n = lit(LiteralValue::Number(10.0));
+        let result = f
+            .dispatch(
+                &[ArgumentHandle::new(&n, &ctx)],
+                &ctx.function_context(None),
+            )
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(result, LiteralValue::Error(_)),
+            "Expected an error, got {result:?}"
+        );
+    }
 }

--- a/crates/formualizer-eval/src/function.rs
+++ b/crates/formualizer-eval/src/function.rs
@@ -148,13 +148,18 @@ pub trait Function: Send + Sync + 'static {
         args: &'c [crate::traits::ArgumentHandle<'a, 'b>],
         ctx: &dyn crate::traits::FunctionContext<'b>,
     ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
-        // Central argument validation
+        // Central argument validation (includes min-arity check)
         {
             use crate::args::{ValidationOptions, validate_and_prepare};
             let schema = self.arg_schema();
-            if let Err(e) =
-                validate_and_prepare(args, schema, ValidationOptions { warn_only: false })
-            {
+            if let Err(e) = validate_and_prepare(
+                args,
+                schema,
+                ValidationOptions {
+                    warn_only: false,
+                    min_args: self.min_args(),
+                },
+            ) {
                 return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e)));
             }
         }

--- a/crates/formualizer-eval/src/tests/validator.rs
+++ b/crates/formualizer-eval/src/tests/validator.rs
@@ -27,7 +27,7 @@ fn validator_enforces_min_args_and_max_when_not_variadic() {
     let schema = vec![s];
 
     // Too many args → #VALUE! is enforced in dispatch, not in validator; validator should accept
-    let res = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false });
+    let res = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false, ..Default::default() });
     assert!(
         res.is_ok(),
         "validator should not enforce max; dispatch enforces max"
@@ -48,7 +48,7 @@ fn schema_scalar_allows_scalar_in_range_position_fallback() {
     s.shape = ShapeKind::Range; // function expects a range, but we provide a scalar
     let schema = vec![s];
 
-    let out = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false }).unwrap();
+    let out = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false, ..Default::default() }).unwrap();
     assert_eq!(out.items.len(), 1);
     match &out.items[0] {
         crate::args::PreparedArg::Value(v) => assert_eq!(v.as_ref(), &LiteralValue::Number(6.0)),
@@ -69,7 +69,7 @@ fn number_lenient_text_coercion_accepts_numeric_text() {
     let s = ArgSchema::number_lenient_scalar();
     let schema = vec![s];
 
-    let out = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false }).unwrap();
+    let out = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false, ..Default::default() }).unwrap();
     assert_eq!(out.items.len(), 1);
     // After Milestone 7: scalar values are coerced per schema. Expect a Number(42.0).
     match &out.items[0] {
@@ -98,7 +98,7 @@ fn by_ref_accepts_ast_reference() {
     s.by_ref = true;
     let schema = vec![s];
 
-    let out = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false }).unwrap();
+    let out = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false, ..Default::default() }).unwrap();
     assert_eq!(out.items.len(), 1);
     match &out.items[0] {
         crate::args::PreparedArg::Reference(r) => match r {


### PR DESCRIPTION
## Summary

- Add `min_args: usize` to `ValidationOptions` so `validate_and_prepare` rejects calls with too few arguments before per-argument validation runs
- `dispatch()` now passes `self.min_args()` into validation, so every function with a declared `min_args` is automatically protected
- Functions like `ROUND(x)` (missing `num_digits`) now return `#VALUE!` instead of panicking with index-out-of-bounds, which previously poisoned the engine mutex and crashed the host process via pyo3 `PanicException`

## Test plan

- [x] `round_one_arg_returns_error_not_panic` — ROUND with 1 arg returns error
- [x] `rounddown_one_arg_returns_error_not_panic` — ROUNDDOWN with 1 arg returns error
- [x] `abs_zero_args_returns_error_not_panic` — ABS with 0 args returns error
- [x] `mod_one_arg_returns_error_not_panic` — MOD with 1 arg returns error
- [x] All 884 existing tests pass (only pre-existing IMEXP/IMSIN/IMCOS fp precision failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)