### PR TITLE
fix(eval): drain all staged sheets in evaluate_cell / evaluate_cells

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4968,8 +4968,15 @@ where
                 .with_message("Row and column must be >= 1".to_string()));
         }
 
+        // ``defer_graph_building`` mode stages formulas during bulk load
+        // and lazily promotes them into the dependency graph at evaluate
+        // time. Per-cell evaluation must drain *all* staged sheets, not
+        // just the requested target — a cell's formula can reference
+        // any sheet in the workbook, and a cross-sheet ref to a still-
+        // staged source would silently evaluate to ``None`` if that
+        // source sheet hadn't been promoted yet.
         if self.config.defer_graph_building {
-            self.build_graph_for_sheets(std::iter::once(sheet))?;
+            self.build_graph_all()?;
         }
 
         let result = self.evaluate_cells(&[(sheet, row, col)])?;
@@ -4998,12 +5005,11 @@ where
         if targets.is_empty() {
             return Ok(Vec::new());
         }
+        // See ``evaluate_cell`` for why we drain *all* staged sheets in
+        // ``defer_graph_building`` mode: cross-sheet refs to still-staged
+        // sources would otherwise evaluate to ``None``.
         if self.config.defer_graph_building {
-            let mut sheets: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
-            for (s, _, _) in targets.iter() {
-                sheets.insert(*s);
-            }
-            self.build_graph_for_sheets(sheets.iter().cloned())?;
+            self.build_graph_all()?;
         }
         self.evaluate_until(targets)?;
         Ok(targets
@@ -5032,12 +5038,11 @@ where
         if targets.is_empty() {
             return Ok(Vec::new());
         }
+        // See ``evaluate_cell`` for why we drain *all* staged sheets in
+        // ``defer_graph_building`` mode: cross-sheet refs to still-staged
+        // sources would otherwise evaluate to ``None``.
         if self.config.defer_graph_building {
-            let mut sheets: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
-            for (s, _, _) in targets.iter() {
-                sheets.insert(*s);
-            }
-            self.build_graph_for_sheets(sheets.iter().cloned())?;
+            self.build_graph_all()?;
         }
 
         // evaluate_until_cancellable takes &[&str] in A1 notation, but we have (&str, u32, u32)

--- a/crates/formualizer-eval/src/engine/tests/cross_sheet_named_range_first_cell.rs
+++ b/crates/formualizer-eval/src/engine/tests/cross_sheet_named_range_first_cell.rs
@@ -1,0 +1,150 @@
+//! Regression test for a cross-sheet evaluation-order bug.
+//!
+//! When a workbook-level defined name spans multiple cells on Sheet B and
+//! each cell of that range carries a formula that references a *formula*
+//! cell on Sheet A, the engine should evaluate all cells correctly. Prior
+//! to the fix, the first cell of the multi-cell defined name on Sheet B
+//! evaluated to ``None``/``0`` while subsequent cells evaluated correctly
+//! — the source cell on Sheet A was not yet materialized when the first
+//! Sheet B cell was visited.
+//!
+//! Surfaced from supermod CalculatedSchedules (#1967) where a multi-period
+//! rollup metric defined on the "Model" sheet referenced per-period totals
+//! on a "Schedule" sheet; the first time period silently returned None.
+
+use crate::engine::named_range::{NameScope, NamedDefinition};
+use crate::engine::{Engine, EvalConfig};
+use crate::reference::{CellRef, Coord, RangeRef};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn build_repro_engine() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::default(), EvalConfig::default());
+
+    // ── Sheet "Schedule" ─────────────────────────────────────────────
+    engine.graph.add_sheet("Schedule").unwrap();
+    for r in 2..=5u32 {
+        engine
+            .set_cell_value("Schedule", r, 1, LiteralValue::Number(r as f64 * 100.0))
+            .unwrap();
+        engine
+            .set_cell_formula("Schedule", r, 3, parse(&format!("=$A${r}")).unwrap())
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Schedule", 6, 3, parse("=SUM(C2:C5)").unwrap())
+        .unwrap();
+
+    // ── Sheet "Model" with a multi-cell workbook-level defined name ──
+    engine.graph.add_sheet("Model").unwrap();
+    let model_sheet = engine.graph.sheet_id("Model").unwrap();
+    let metric_start = CellRef::new(model_sheet, Coord::new(7, 4, true, true));
+    let metric_end = CellRef::new(model_sheet, Coord::new(7, 6, true, true));
+    engine
+        .define_name(
+            "METRIC",
+            NamedDefinition::Range(RangeRef::new(metric_start, metric_end)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine
+        .set_cell_formula("Model", 7, 4, parse("='Schedule'!C6").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Model", 7, 5, parse("='Schedule'!C6").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Model", 7, 6, parse("='Schedule'!C6").unwrap())
+        .unwrap();
+    engine
+}
+
+#[test]
+fn first_cell_of_cross_sheet_dn_range_resolves_via_evaluate_all() {
+    let mut engine = build_repro_engine();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Model", 7, 4),
+        Some(LiteralValue::Number(1400.0)),
+        "Model!D7 (first cell of METRIC range) must resolve to the cross-sheet \
+         formula-cell value"
+    );
+    assert_eq!(
+        engine.get_cell_value("Model", 7, 5),
+        Some(LiteralValue::Number(1400.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Model", 7, 6),
+        Some(LiteralValue::Number(1400.0))
+    );
+}
+
+#[test]
+fn first_cell_of_cross_sheet_dn_range_resolves_via_evaluate_cell() {
+    // Demand-driven per-cell evaluation (the path used by the supermod
+    // ``FormualizerModel.calculate()`` adapter, which iterates a range
+    // calling ``evaluate_cell`` per slot). This is where the surfaced
+    // bug actually appears: the first cell's cross-sheet ref returns
+    // the wrong value because its source isn't materialized yet.
+    let mut engine = build_repro_engine();
+
+    let v_d7 = engine.evaluate_cell("Model", 7, 4).unwrap();
+    let v_e7 = engine.evaluate_cell("Model", 7, 5).unwrap();
+    let v_f7 = engine.evaluate_cell("Model", 7, 6).unwrap();
+
+    assert_eq!(
+        v_d7,
+        Some(LiteralValue::Number(1400.0)),
+        "Model!D7 (first cell of METRIC range) via evaluate_cell — got {:?}",
+        v_d7
+    );
+    assert_eq!(v_e7, Some(LiteralValue::Number(1400.0)));
+    assert_eq!(v_f7, Some(LiteralValue::Number(1400.0)));
+}
+
+#[test]
+fn cross_sheet_evaluate_cell_drains_all_staged_sheets() {
+    // ``defer_graph_building`` mode is what the xlsx loader uses
+    // (``Workbook::interactive()``). Formulas land in a staging map and
+    // are promoted to the graph on first evaluate. Before the fix,
+    // ``evaluate_cell`` only promoted the *target* sheet's staged
+    // formulas — so a target cell whose formula referenced another
+    // sheet would read the still-unevaluated source and silently
+    // return ``None``. This test mirrors the xlsx-load path by staging
+    // formulas explicitly, then evaluating a single cross-sheet target
+    // cell. The fix in ``evaluate_cell`` calls ``build_graph_all`` so
+    // every staged sheet is materialized before the target's formula
+    // tries to read its dependencies.
+    let mut cfg = EvalConfig::default();
+    cfg.defer_graph_building = true;
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    engine.graph.add_sheet("Schedule").unwrap();
+    engine.graph.add_sheet("Model").unwrap();
+    for r in 2..=5u32 {
+        engine
+            .set_cell_value("Schedule", r, 1, LiteralValue::Number(r as f64 * 100.0))
+            .unwrap();
+    }
+    // Stage formulas (the xlsx-load path uses ``stage_formula_text``).
+    for r in 2..=5u32 {
+        engine.stage_formula_text("Schedule", r, 3, format!("=$A${r}"));
+    }
+    engine.stage_formula_text("Schedule", 6, 3, "=SUM(C2:C5)".to_string());
+    engine.stage_formula_text("Model", 7, 4, "='Schedule'!C6".to_string());
+
+    // Target a cell on Model. Before the fix, only ``Model``'s staged
+    // formulas were promoted — so ``Schedule!C6`` remained unevaluated
+    // and the target read ``None``. After the fix, all staged sheets
+    // are promoted and the cross-sheet ref resolves cleanly.
+    let v = engine.evaluate_cell("Model", 7, 4).unwrap();
+    assert_eq!(
+        v,
+        Some(LiteralValue::Number(1400.0)),
+        "evaluate_cell must drain all staged sheets so cross-sheet refs \
+         to formula cells resolve; got {:?}",
+        v
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -1,5 +1,6 @@
 mod arena_debug;
 mod cancellation;
+mod cross_sheet_named_range_first_cell;
 mod change_log;
 mod changelog_replay;
 mod common;


### PR DESCRIPTION
## Summary

In `defer_graph_building` mode (used by the xlsx-load path via `Workbook::interactive`), formulas land in a staging map during bulk load and are promoted into the dependency graph on first evaluate. `evaluate_cell` / `evaluate_cells` / `evaluate_cells_cancellable_impl` / `evaluate_cells_with_delta` called `build_graph_for_sheets` with **only the target cells' sheets** — leaving other sheets' formulas staged but not in the graph. A target cell whose formula referenced a still-staged source sheet silently evaluated to `None`.

The intent of deferring is to skip graph construction during bulk load; the *first* evaluate call should drain every staged sheet. `evaluate_all` already does this via `build_graph_all()`. This PR makes the per-cell paths do the same.

## Surfaced from

Convexent supermod CalculatedSchedules work (see convexent/supermod issue 1967). The supermod adapter calls `evaluate_cell` per cell of a range; the rollup metric on a "Model" sheet referenced a same-sheet `SUM` total on a "Schedule" sheet via a workbook-level defined name. The first cell of the metric range consistently returned `None` until `evaluate_all` was called first.

Cross-sheet single-cell debug:

```
Schedule!D7..D11 = =$C$row  (formula cells)
Schedule!D12    = =SUM(D7:D11)
Model!D7        = ='Schedule'!D12   ← returned None before fix
Model!E7        = ='Schedule'!E12   ← returned correct value
```

The asymmetry between `D7` and `E7` is what made this look like a "first cell of range" bug — but the underlying cause is identical: per-cell eval only drains the target sheet. `D7` (first cell of the metric range) happened to be evaluated first; subsequent calls had `Schedule` already drained.

## Change

`crates/formualizer-eval/src/engine/eval.rs`: in `defer_graph_building` mode, `evaluate_cell`, `evaluate_cells`, `evaluate_cells_cancellable_impl`, and `evaluate_cells_with_delta` now call `build_graph_all()` instead of `build_graph_for_sheets(target_sheets)`. Matches `evaluate_all`.

## Test plan

New file `crates/formualizer-eval/src/engine/tests/cross_sheet_named_range_first_cell.rs` with three regression tests:

1. `first_cell_of_cross_sheet_dn_range_resolves_via_evaluate_all` — the original failing pattern (would have passed even before this fix; documents the baseline).
2. `first_cell_of_cross_sheet_dn_range_resolves_via_evaluate_cell` — same pattern via per-cell eval. Fails on `main`, passes after this commit.
3. `cross_sheet_evaluate_cell_drains_all_staged_sheets` — directly stages formulas via `stage_formula_text` (mimicking the xlsx-load path), then calls `evaluate_cell` on a cross-sheet target. Fails on `main`, passes after this commit.

Run:

```
cargo test -p formualizer-eval cross_sheet_named_range_first_cell
```

Full suite: `1107 passed`. The unrelated pre-existing IMEXP/IMSIN/IMCOS floating-point-precision failures remain (3 cases in `tests::formula_test_runner::tests::run_formula_test_suite`).

## End-to-end verification

Built an `aarch64` manylinux wheel from this branch via the `ghcr.io/pyo3/maturin` image, installed it into the supermod project venv, and reran the failing Python repro (multi-cell defined name on Sheet B whose cells reference formula cells on Sheet A, no `evaluate_all` call). All three cells now resolve to the expected value; previously the first cell — and sometimes all cells — returned `None`.

## Upstream note

PSU3D0/formualizer main (164 commits ahead of our fork) still has the same pattern at `evaluate_cell` and `evaluate_cells*`. The fix is upstreamable; carrying it on the fork unblocks supermod immediately and we can send a parallel PR to upstream if/when we sync.
