### PR TITLE
fix(eval): route date-function coercion through to_number_lenient (EDATE/HOUR/...)

### DIFF
--- a/crates/formualizer-eval/src/builtins/datetime/date_parts.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/date_parts.rs
@@ -1,6 +1,6 @@
 //! Date and time component extraction functions
 
-use super::serial::{date_to_serial, datetime_to_serial, serial_to_date, serial_to_datetime};
+use super::serial::{serial_to_date, serial_to_datetime};
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
@@ -10,20 +10,12 @@ use formualizer_macros::func_caps;
 
 fn coerce_to_serial(arg: &ArgumentHandle) -> Result<f64, ExcelError> {
     let v = arg.value()?.into_literal();
-    match v {
-        LiteralValue::Number(f) => Ok(f),
-        LiteralValue::Int(i) => Ok(i as f64),
-        LiteralValue::Date(d) => Ok(date_to_serial(&d)),
-        LiteralValue::DateTime(dt) => Ok(datetime_to_serial(&dt)),
-        LiteralValue::Text(s) => s.parse::<f64>().map_err(|_| {
-            ExcelError::new_value().with_message("Date/time serial is not a valid number")
-        }),
-        LiteralValue::Boolean(b) => Ok(if b { 1.0 } else { 0.0 }),
-        LiteralValue::Empty => Ok(0.0),
-        LiteralValue::Error(e) => Err(e),
-        _ => Err(ExcelError::new_value()
-            .with_message("Date/time functions expect numeric or text-numeric serials")),
+    if let LiteralValue::Error(e) = v {
+        return Err(e);
     }
+    crate::coercion::to_number_lenient(&v).map_err(|_| {
+        ExcelError::new_value().with_message("Date/time functions expect a numeric serial value")
+    })
 }
 
 fn coerce_to_date(arg: &ArgumentHandle) -> Result<NaiveDate, ExcelError> {

--- a/crates/formualizer-eval/src/builtins/datetime/edate_eomonth.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/edate_eomonth.rs
@@ -10,34 +10,26 @@ use formualizer_macros::func_caps;
 
 fn coerce_to_serial(arg: &ArgumentHandle) -> Result<f64, ExcelError> {
     let v = arg.value()?.into_literal();
-    match v {
-        LiteralValue::Number(f) => Ok(f),
-        LiteralValue::Int(i) => Ok(i as f64),
-        LiteralValue::Text(s) => s.parse::<f64>().map_err(|_| {
-            ExcelError::new_value().with_message("EDATE/EOMONTH start_date is not a valid number")
-        }),
-        LiteralValue::Boolean(b) => Ok(if b { 1.0 } else { 0.0 }),
-        LiteralValue::Empty => Ok(0.0),
-        LiteralValue::Error(e) => Err(e),
-        _ => Err(ExcelError::new_value()
-            .with_message("EDATE/EOMONTH expects numeric or text-numeric arguments")),
+    if let LiteralValue::Error(e) = v {
+        return Err(e);
     }
+    crate::coercion::to_number_lenient(&v).map_err(|_| {
+        ExcelError::new_value()
+            .with_message("EDATE/EOMONTH expects numeric, date, or text-numeric arguments")
+    })
 }
 
 fn coerce_to_int(arg: &ArgumentHandle) -> Result<i32, ExcelError> {
     let v = arg.value()?.into_literal();
-    match v {
-        LiteralValue::Int(i) => Ok(i as i32),
-        LiteralValue::Number(f) => Ok(f.trunc() as i32),
-        LiteralValue::Text(s) => s.parse::<f64>().map(|f| f.trunc() as i32).map_err(|_| {
-            ExcelError::new_value().with_message("EDATE/EOMONTH months is not a valid number")
-        }),
-        LiteralValue::Boolean(b) => Ok(if b { 1 } else { 0 }),
-        LiteralValue::Empty => Ok(0),
-        LiteralValue::Error(e) => Err(e),
-        _ => Err(ExcelError::new_value()
-            .with_message("EDATE/EOMONTH expects numeric or text-numeric arguments")),
+    if let LiteralValue::Error(e) = v {
+        return Err(e);
     }
+    crate::coercion::to_number_lenient(&v)
+        .map(|f| f.trunc() as i32)
+        .map_err(|_| {
+            ExcelError::new_value()
+                .with_message("EDATE/EOMONTH months argument is not a valid number")
+        })
 }
 
 /// Returns the serial date offset by a whole number of months from a start date.

--- a/crates/formualizer-eval/src/builtins/datetime/weekday_workday.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/weekday_workday.rs
@@ -19,31 +19,20 @@ fn non_leap_day_of_year(month: u32, day: u32) -> i64 {
 
 fn coerce_to_serial(arg: &ArgumentHandle) -> Result<f64, ExcelError> {
     let v = arg.value()?.into_literal();
-    match v {
-        LiteralValue::Number(f) => Ok(f),
-        LiteralValue::Int(i) => Ok(i as f64),
-        LiteralValue::Date(d) => Ok(date_to_serial(&d)),
-        LiteralValue::DateTime(dt) => Ok(date_to_serial(&dt.date())),
-        LiteralValue::Text(s) => s
-            .parse::<f64>()
-            .map_err(|_| ExcelError::new_value().with_message("Not a valid number")),
-        LiteralValue::Boolean(b) => Ok(if b { 1.0 } else { 0.0 }),
-        LiteralValue::Empty => Ok(0.0),
-        LiteralValue::Error(e) => Err(e),
-        _ => Err(ExcelError::new_value()),
+    if let LiteralValue::Error(e) = v {
+        return Err(e);
     }
+    crate::coercion::to_number_lenient(&v).map_err(|_| ExcelError::new_value())
 }
 
 fn coerce_to_int(arg: &ArgumentHandle) -> Result<i64, ExcelError> {
     let v = arg.value()?.into_literal();
-    match v {
-        LiteralValue::Number(f) => Ok(f.trunc() as i64),
-        LiteralValue::Int(i) => Ok(i),
-        LiteralValue::Boolean(b) => Ok(if b { 1 } else { 0 }),
-        LiteralValue::Empty => Ok(0),
-        LiteralValue::Error(e) => Err(e),
-        _ => Err(ExcelError::new_value()),
+    if let LiteralValue::Error(e) = v {
+        return Err(e);
     }
+    crate::coercion::to_number_lenient(&v)
+        .map(|f| f.trunc() as i64)
+        .map_err(|_| ExcelError::new_value())
 }
 
 /// Returns the day-of-week index for a date serial with configurable numbering.

--- a/crates/formualizer-eval/src/engine/tests/date_function_duration_cells.rs
+++ b/crates/formualizer-eval/src/engine/tests/date_function_duration_cells.rs
@@ -1,0 +1,61 @@
+use chrono::Duration;
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn run(formula: &str, a1: LiteralValue) -> Option<LiteralValue> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.set_cell_value("Sheet1", 1, 1, a1).unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse(formula).unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine.get_cell_value("Sheet1", 1, 2)
+}
+
+fn dur_2d_14h_30m_45s() -> LiteralValue {
+    LiteralValue::Duration(Duration::seconds(2 * 86_400 + 14 * 3600 + 30 * 60 + 45))
+}
+
+fn assert_int_like(v: Option<LiteralValue>, expected: i64) {
+    match v {
+        Some(LiteralValue::Int(n)) => assert_eq!(n, expected),
+        Some(LiteralValue::Number(n)) => assert!(
+            (n - expected as f64).abs() < 1e-9,
+            "expected ~{expected}, got {n}",
+        ),
+        other => panic!("expected integer-like {expected}, got {other:?}"),
+    }
+}
+
+#[test]
+fn hour_on_duration_cell_returns_fraction_hours() {
+    assert_int_like(run("=HOUR(A1)", dur_2d_14h_30m_45s()), 14);
+}
+
+#[test]
+fn minute_on_duration_cell_returns_fraction_minutes() {
+    assert_int_like(run("=MINUTE(A1)", dur_2d_14h_30m_45s()), 30);
+}
+
+#[test]
+fn second_on_duration_cell_returns_fraction_seconds() {
+    assert_int_like(run("=SECOND(A1)", dur_2d_14h_30m_45s()), 45);
+}
+
+#[test]
+fn weekday_on_duration_cell_does_not_value_error() {
+    let r = run(
+        "=WEEKDAY(A1)",
+        LiteralValue::Duration(Duration::days(45657)),
+    );
+    match r {
+        Some(LiteralValue::Int(n)) => assert!((1..=7).contains(&n), "weekday out of range: {n}"),
+        Some(LiteralValue::Number(n)) => {
+            assert!((1.0..=7.0).contains(&n), "weekday out of range: {n}")
+        }
+        other => panic!("expected weekday integer, got {other:?}"),
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/edate_eomonth_engine.rs
+++ b/crates/formualizer-eval/src/engine/tests/edate_eomonth_engine.rs
@@ -1,0 +1,68 @@
+use chrono::NaiveDate;
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+}
+
+fn assert_date_like(v: Option<LiteralValue>, expected: NaiveDate) {
+    match v {
+        Some(LiteralValue::Date(d)) => assert_eq!(d, expected),
+        Some(LiteralValue::DateTime(dt)) => assert_eq!(dt.date(), expected),
+        Some(LiteralValue::Number(n)) => {
+            let got = NaiveDate::from_ymd_opt(1899, 12, 30).unwrap()
+                + chrono::Duration::days(n.trunc() as i64);
+            assert_eq!(got, expected, "serial {n} did not map to {expected}");
+        }
+        other => panic!("expected date-like {expected:?}, got {other:?}"),
+    }
+}
+
+fn run_edate(start: NaiveDate, months: i64) -> Option<LiteralValue> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Date(start))
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            1,
+            2,
+            parse(&format!("=EDATE($A$1, {months})")).unwrap(),
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine.get_cell_value("Sheet1", 1, 2)
+}
+
+#[test]
+fn edate_with_date_cell_adds_months_preserving_day() {
+    assert_date_like(run_edate(date(2025, 2, 4), 15), date(2026, 5, 4));
+}
+
+#[test]
+fn edate_with_date_cell_clamps_to_month_end() {
+    assert_date_like(run_edate(date(2025, 1, 31), 1), date(2025, 2, 28));
+}
+
+#[test]
+fn edate_with_date_cell_handles_negative_months() {
+    assert_date_like(run_edate(date(2025, 3, 15), -3), date(2024, 12, 15));
+}
+
+#[test]
+fn eomonth_with_date_cell_returns_month_end() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Date(date(2025, 2, 4)))
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=EOMONTH($A$1, 0)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_date_like(engine.get_cell_value("Sheet1", 1, 2), date(2025, 2, 28));
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -59,6 +59,7 @@ mod spill_semantics_101;
 mod date_arithmetic_ops;
 mod date_math_parity;
 mod edate_eomonth_engine;
+mod date_function_duration_cells;
 
 mod hardening_503;
 

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -58,6 +58,7 @@ mod spill_semantics_101;
 
 mod date_arithmetic_ops;
 mod date_math_parity;
+mod edate_eomonth_engine;
 
 mod hardening_503;
 

--- a/tests/formula_tests/date_time.json
+++ b/tests/formula_tests/date_time.json
@@ -389,6 +389,42 @@
       "description": "EOMONTH 3 months backward from serial 444"
     },
     {
+      "formula": "=EDATE(A1, 15)",
+      "result": 46146,
+      "result_type": "int",
+      "description": "EDATE adds months to a native Date cell, preserving day",
+      "context": {
+        "A1": {"type": "date", "value": "2025-02-04"}
+      }
+    },
+    {
+      "formula": "=EDATE(A1, 1)",
+      "result": 45716,
+      "result_type": "int",
+      "description": "EDATE clamps day-of-month overflow when target month is shorter",
+      "context": {
+        "A1": {"type": "date", "value": "2025-01-31"}
+      }
+    },
+    {
+      "formula": "=EDATE(A1, -3)",
+      "result": 45641,
+      "result_type": "int",
+      "description": "EDATE accepts negative months from a native Date cell",
+      "context": {
+        "A1": {"type": "date", "value": "2025-03-15"}
+      }
+    },
+    {
+      "formula": "=EOMONTH(A1, 0)",
+      "result": 45716,
+      "result_type": "int",
+      "description": "EOMONTH on a native Date cell returns the month-end serial",
+      "context": {
+        "A1": {"type": "date", "value": "2025-02-04"}
+      }
+    },
+    {
       "formula": "=WEEKNUM(0, 1)",
       "result": 0,
       "result_type": "int",


### PR DESCRIPTION
## Summary

Three date-builtin files reimplemented numeric-argument coercion locally with a `match v { Number => ..., Int => ..., Date => ..., ... _ => #VALUE! }` pattern. The catch-all arm caught one or more of `LiteralValue::Date`, `DateTime`, `Time`, and `Duration` — variants the canonical `crate::coercion::to_number_lenient` (used by every other numeric builtin) handles via `LiteralValue::as_serial_number()`. Two real, observable bugs:

| File | Functions | Missing variants | Real bug |
|---|---|---|---|
| `edate_eomonth.rs` | EDATE, EOMONTH | Date, DateTime, Time, Duration | `=EDATE(date_cell, n)` always returned `#VALUE!` |
| `date_parts.rs` | YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, DAYS, DAYS360, YEARFRAC, ISOWEEKNUM | Time, Duration | `=HOUR(duration_cell)` returned `#VALUE!` |
| `weekday_workday.rs` | WEEKDAY, WEEKNUM, DATEDIF, NETWORKDAYS, WORKDAY | Time, Duration | Same pattern; Duration→WEEKDAY etc. returned `#VALUE!` |

(Time-cell variants are moot in practice — the Arrow store normalizes `LiteralValue::Time` to `LiteralValue::DateTime(1899-12-31T<hh:mm:ss>)` on ingest, so a function never sees `Time` from a cell read. Duration is preserved at storage and is the variant that bites.)

This PR routes all three files' local coercion helpers through `crate::coercion::to_number_lenient`, the same lenient path other date builtins already use. `Error` is short-circuited up front to preserve error propagation. Helpers stay local (no centralization) — the goal is parity, not refactor scope.

## Surfaced from

EDATE was found while building a 506-site lease forecast in supermod (issue 1967): `EDATE(commencement, term_months)` against date cells always errored. The follow-on audit found the same pattern in the other two files; the Duration case was confirmed via probe (`=A1+0` returned `Number(2.0)` on a 48-hour Duration cell, but `=HOUR(A1)` returned `#VALUE!`).

The original supermod workaround for EDATE was inline expansion to `DATE(YEAR(d) + INT((MONTH(d)-1+N)/12), MOD(MONTH(d)-1+N, 12)+1, DAY(d))`. After this fix that becomes `=EDATE(d, N)`.

## Change

- `crates/formualizer-eval/src/builtins/datetime/edate_eomonth.rs`: `coerce_to_serial` and `coerce_to_int` route through `to_number_lenient`.
- `crates/formualizer-eval/src/builtins/datetime/date_parts.rs`: same change to `coerce_to_serial`.
- `crates/formualizer-eval/src/builtins/datetime/weekday_workday.rs`: same change to `coerce_to_serial` and `coerce_to_int`.

`date_time.rs` (DATE, TIME) and `date_value.rs` (DATEVALUE, TIMEVALUE) were audited and intentionally left alone — DATE/TIME take integer year/month/day/hour/minute/second args where date-cell coercion isn't semantically meaningful, and DATEVALUE/TIMEVALUE are text-only by Excel spec.

## Test plan

**Engine-level (Rust):**

- New `crates/formualizer-eval/src/engine/tests/edate_eomonth_engine.rs` — 4 cases: `EDATE(2025-02-04, 15)` → `2026-05-04`, `EDATE(2025-01-31, 1)` → `2025-02-28` (clamp), `EDATE(2025-03-15, -3)` → `2024-12-15` (negative), `EOMONTH(2025-02-04, 0)` → `2025-02-28`.
- New `crates/formualizer-eval/src/engine/tests/date_function_duration_cells.rs` — 4 cases: `HOUR`/`MINUTE`/`SECOND` on a `Duration::seconds(2*86400 + 14h + 30m + 45s)` cell return `14`/`30`/`45`; `WEEKDAY` on a Duration cell returns an in-range weekday integer instead of `#VALUE!`.

All 8 fail on `main`; all 8 pass after this branch.

**JSON suite:** `tests/formula_tests/date_time.json` gains 4 EDATE/EOMONTH cases that use `context: { \"A1\": { \"type\": \"date\", \"value\": ... } }`. The existing JSON cases for EDATE/EOMONTH only ever pass numeric serials or `DATE(...)` results (both arrive as `Number`), so they couldn't have caught the date-cell bug. (No JSON cases added for Duration — `formula_test_runner`'s `json_typed_value` doesn't have a `\"duration\"` type and extending it is out of scope here.)

Run:

```
cargo test -p formualizer-eval edate_eomonth_engine
cargo test -p formualizer-eval date_function_duration_cells
cargo test -p formualizer-eval --lib tests::formula_test_runner
```

Full suite: `1115 passed` (+4 over `main`'s 1111). `formula_test_runner` reports `759 passed` (+4 over `main`'s 755). The unrelated pre-existing IMEXP/IMSIN/IMCOS floating-point-precision failures remain (3 cases in `tests::formula_test_runner::tests::run_formula_test_suite`); verified to also fail on `main` without this change.

## Upstream note

PSU3D0/formualizer main has the same patterns in all three files; the fix is upstreamable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)