### PR TITLE
perf(eval): batch redirty_volatiles into a single traversal (O(V*N) -> O(N))

### DIFF
--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -1889,12 +1889,61 @@ impl DependencyGraph {
         self.volatile_vertices.clear();
     }
 
-    /// Re-marks all volatile vertices as dirty for the next evaluation cycle.
+    /// Re-marks all volatile vertices (and their transitive dependents) as dirty
+    /// for the next evaluation cycle.
+    ///
+    /// This is the batched equivalent of calling [`Self::mark_dirty`] once per
+    /// volatile vertex: it produces the identical dirty set, but walks the union
+    /// of the volatiles' transitive dependent cones with a SINGLE shared `visited`
+    /// set instead of re-walking overlapping cones once per volatile. The naive
+    /// per-volatile form is O(V·N) when volatiles sit near the dependency root
+    /// (every volatile's cone covers a large fraction of the graph), which on
+    /// large workbooks dominates evaluation entirely (see convexent/supermod#2130:
+    /// ~219s of a 219.2s `evaluate_cell`). The shared-visited traversal is
+    /// O(N + edges).
     pub(crate) fn redirty_volatiles(&mut self) {
-        let volatile_ids: Vec<VertexId> = self.volatile_vertices.iter().copied().collect();
-        for id in volatile_ids {
-            self.mark_dirty(id);
+        if self.volatile_vertices.is_empty() {
+            return;
         }
+
+        let mut affected: FxHashSet<VertexId> = FxHashSet::default();
+        let mut visited: FxHashSet<VertexId> = FxHashSet::default();
+        let mut to_visit: Vec<VertexId> = Vec::new();
+
+        // Seed-level expansion for every volatile vertex, mirroring the pre-loop
+        // block of `mark_dirty` (which expands name-dependents only at the seed).
+        // Volatile vertices are formula vertices, so each is itself re-dirtied.
+        let volatile_ids: Vec<VertexId> = self.volatile_vertices.iter().copied().collect();
+        for &v in &volatile_ids {
+            to_visit.push(v);
+            if let Some(dependents) = self.dependents_slice(v) {
+                to_visit.extend(dependents.iter().copied());
+            } else {
+                to_visit.extend(self.get_dependents(v));
+            }
+            if let Some(name_set) = self.cell_to_name_dependents.get(&v) {
+                to_visit.extend(name_set.iter().copied());
+            }
+            to_visit.extend(self.collect_range_dependents_for_vertex(v));
+        }
+
+        // Single shared-visited propagation over the union of all volatile cones.
+        while let Some(id) = to_visit.pop() {
+            if !visited.insert(id) {
+                continue;
+            }
+            affected.insert(id);
+            self.store.set_dirty(id, true);
+
+            if let Some(dependents) = self.dependents_slice(id) {
+                to_visit.extend(dependents.iter().copied());
+            } else {
+                to_visit.extend(self.get_dependents(id));
+            }
+            to_visit.extend(self.collect_range_dependents_for_vertex(id));
+        }
+
+        self.dirty_vertices.extend(&affected);
     }
 
     fn get_or_create_vertex(

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -1901,12 +1901,20 @@ impl DependencyGraph {
     /// large workbooks dominates evaluation entirely (see convexent/supermod#2130:
     /// ~219s of a 219.2s `evaluate_cell`). The shared-visited traversal is
     /// O(N + edges).
+    ///
+    /// Equivalence to the per-volatile form relies on every entry in
+    /// `volatile_vertices` being a formula vertex (`mark_dirty` only pushes its
+    /// seed into the walk when `is_formula`; here we push every seed
+    /// unconditionally). That invariant holds because all `mark_volatile` call
+    /// sites set a `Formula*` kind before registering the vertex as volatile.
     pub(crate) fn redirty_volatiles(&mut self) {
         if self.volatile_vertices.is_empty() {
             return;
         }
 
-        let mut affected: FxHashSet<VertexId> = FxHashSet::default();
+        // `visited` doubles as the affected set: every vertex is added on its
+        // first (and only) visit, so the final `visited` is exactly the dirty
+        // set to record.
         let mut visited: FxHashSet<VertexId> = FxHashSet::default();
         let mut to_visit: Vec<VertexId> = Vec::new();
 
@@ -1932,7 +1940,6 @@ impl DependencyGraph {
             if !visited.insert(id) {
                 continue;
             }
-            affected.insert(id);
             self.store.set_dirty(id, true);
 
             if let Some(dependents) = self.dependents_slice(id) {
@@ -1943,7 +1950,7 @@ impl DependencyGraph {
             to_visit.extend(self.collect_range_dependents_for_vertex(id));
         }
 
-        self.dirty_vertices.extend(&affected);
+        self.dirty_vertices.extend(&visited);
     }
 
     fn get_or_create_vertex(

--- a/crates/formualizer-eval/src/engine/tests/cross_sheet_named_range_first_cell.rs
+++ b/crates/formualizer-eval/src/engine/tests/cross_sheet_named_range_first_cell.rs
@@ -29,7 +29,7 @@ fn build_repro_engine() -> Engine<TestWorkbook> {
             .set_cell_value("Schedule", r, 1, LiteralValue::Number(r as f64 * 100.0))
             .unwrap();
         engine
-            .set_cell_formula("Schedule", r, 3, parse(&format!("=$A${r}")).unwrap())
+            .set_cell_formula("Schedule", r, 3, parse(format!("=$A${r}")).unwrap())
             .unwrap();
     }
     engine
@@ -117,8 +117,10 @@ fn cross_sheet_evaluate_cell_drains_all_staged_sheets() {
     // cell. The fix in ``evaluate_cell`` calls ``build_graph_all`` so
     // every staged sheet is materialized before the target's formula
     // tries to read its dependencies.
-    let mut cfg = EvalConfig::default();
-    cfg.defer_graph_building = true;
+    let cfg = EvalConfig {
+        defer_graph_building: true,
+        ..Default::default()
+    };
     let mut engine = Engine::new(TestWorkbook::default(), cfg);
 
     engine.graph.add_sheet("Schedule").unwrap();

--- a/crates/formualizer-eval/src/engine/tests/edate_eomonth_engine.rs
+++ b/crates/formualizer-eval/src/engine/tests/edate_eomonth_engine.rs
@@ -32,7 +32,7 @@ fn run_edate(start: NaiveDate, months: i64) -> Option<LiteralValue> {
             "Sheet1",
             1,
             2,
-            parse(&format!("=EDATE($A$1, {months})")).unwrap(),
+            parse(format!("=EDATE($A$1, {months})")).unwrap(),
         )
         .unwrap();
     engine.evaluate_all().unwrap();

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -20,6 +20,7 @@ mod parallel;
 mod range_dependencies;
 mod range_property_tests;
 mod recalc_plan;
+mod redirty_volatiles_perf;
 mod schedule_cache;
 mod schedule_integration;
 mod sheet_index_integration;

--- a/crates/formualizer-eval/src/engine/tests/redirty_volatiles_perf.rs
+++ b/crates/formualizer-eval/src/engine/tests/redirty_volatiles_perf.rs
@@ -11,9 +11,20 @@
 //! intermediate `SUM`, which is the head of a length-N dependency CHAIN
 //! (each cell references the previous). Every volatile's cone is therefore the
 //! same ~N-vertex chain. Pre-fix, re-dirtying re-walks that chain once per
-//! volatile = V·N visits (seconds at this size); the batched-traversal fix walks
-//! it once = O(N). The blowup is carried by V (cheap cells), keeping chain depth
-//! — and thus per-pass evaluation — modest so the test stays fast post-fix.
+//! volatile = V·N visits; the batched-traversal fix walks it once = O(N). The
+//! blowup is carried by V (cheap cells), keeping chain depth — and thus per-pass
+//! evaluation — modest so the test stays fast post-fix.
+//!
+//! Measured (debug, `cargo test -p formualizer-eval`) at V=20000, N=2000, with
+//! the fix reverted vs applied — i.e. the bound was watched go red:
+//!   pre-fix  (per-volatile mark_dirty): second evaluate_all ~= 38.7s  -> FAILS
+//!   post-fix (batched traversal):       second evaluate_all ~=  0.29s -> passes
+//! The 5s bound therefore sits ~7.7x under the pre-fix time and ~17x over the
+//! post-fix time. Each pre-fix cone-visit costs ~1us (a
+//! `collect_range_dependents_for_vertex` allocation plus hash-set work), so
+//! V*N ~= 40M lands at ~39s rather than the low single-digit seconds a cheaper
+//! per-visit cost would imply. V is held at 20000 (not higher) to bound the
+//! one-time ~22k-cell setup; the timed region itself is sub-second.
 
 use super::common::create_cell_ref_ast;
 use crate::builtins::random::register_builtins;

--- a/crates/formualizer-eval/src/engine/tests/redirty_volatiles_perf.rs
+++ b/crates/formualizer-eval/src/engine/tests/redirty_volatiles_perf.rs
@@ -1,0 +1,100 @@
+//! Regression guard for convexent/supermod#2130.
+//!
+//! `redirty_volatiles` used to call `mark_dirty` once per volatile vertex, and
+//! `mark_dirty` walks the full transitive dependent cone with a fresh `visited`
+//! set each time. When many volatiles share a large dependent cone, that is
+//! O(V·N) and dominated evaluation on real workbooks (~219s of a 219s
+//! `evaluate_cell`). The fix walks the union of cones once.
+//!
+//! Shape (chosen for O(V+N) construction — no high-fan-out vertex, which would
+//! make graph-building itself O(N²)): V volatile `RAND()` cells feed one
+//! intermediate `SUM`, which is the head of a length-N dependency CHAIN
+//! (each cell references the previous). Every volatile's cone is therefore the
+//! same ~N-vertex chain. Pre-fix, re-dirtying re-walks that chain once per
+//! volatile = V·N visits (seconds at this size); the batched-traversal fix walks
+//! it once = O(N). The blowup is carried by V (cheap cells), keeping chain depth
+//! — and thus per-pass evaluation — modest so the test stays fast post-fix.
+
+use super::common::create_cell_ref_ast;
+use crate::builtins::random::register_builtins;
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_parse::parser::{ASTNode, ASTNodeType};
+use std::time::{Duration, Instant};
+
+#[test]
+fn redirty_volatiles_is_not_quadratic_in_volatiles() {
+    register_builtins();
+    let wb = TestWorkbook::new();
+    let mut engine = Engine::new(wb, EvalConfig::default());
+
+    const V: u32 = 20_000; // volatile sources (cheap; carries the V·N blowup)
+    const N: u32 = 2_000; // chain depth (the cone each volatile re-walks)
+
+    // Column 2, rows 1..=V: =RAND() (volatile). Laid out down a column (rows,
+    // max ~1M) to stay within the 16384-column limit. Each has fan-out 1
+    // (referenced only by the intermediate SUM), so construction stays O(V).
+    let mut vol_refs = Vec::with_capacity(V as usize);
+    for row in 1..=V {
+        engine
+            .set_cell_formula(
+                "Sheet1",
+                row,
+                2,
+                ASTNode {
+                    node_type: ASTNodeType::Function {
+                        name: "RAND".into(),
+                        args: vec![],
+                    },
+                    source_token: None,
+                    contains_volatile: true,
+                },
+            )
+            .unwrap();
+        vol_refs.push(create_cell_ref_ast(None, row, 2));
+    }
+
+    // Intermediate at (1,1) = SUM(all volatiles): a dependent of every volatile,
+    // and the head of the chain below.
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            1,
+            1,
+            ASTNode {
+                node_type: ASTNodeType::Function {
+                    name: "SUM".into(),
+                    args: vol_refs,
+                },
+                source_token: None,
+                contains_volatile: false,
+            },
+        )
+        .unwrap();
+
+    // Chain of length N down column 1: cell at row r references row r-1
+    // (fan-out 1 each). (2,1)=R1C1 (the intermediate), (3,1)=R2C1, ... so the
+    // whole chain is downstream of every volatile via the intermediate.
+    for r in 2..(2 + N) {
+        engine
+            .set_cell_formula("Sheet1", r, 1, create_cell_ref_ast(None, r - 1, 1))
+            .unwrap();
+    }
+
+    // Prime: first solve also re-dirties the volatile cone at the end.
+    engine.evaluate_all().unwrap();
+
+    // Timed: a second full solve re-evaluates the re-dirtied cone and calls
+    // redirty_volatiles again — the operation that was O(V·N) before the fix.
+    let t = Instant::now();
+    engine.evaluate_all().unwrap();
+    let elapsed = t.elapsed();
+    eprintln!("[2130 guard] second evaluate_all (V={V}, N={N}): {elapsed:?}");
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "redirty_volatiles appears quadratic again: second evaluate_all took {elapsed:?} \
+         for V={V} volatiles x N={N} chain (expected well under 5s after the \
+         batched-traversal fix for convexent/supermod#2130)"
+    );
+}


### PR DESCRIPTION
## Summary

`redirty_volatiles()` (run at the end of every `evaluate_until` / `evaluate_all` pass that does any work) called `mark_dirty()` **once per volatile vertex**, and `mark_dirty` walks the full transitive dependent cone with a fresh `visited` set each call. When volatiles sit near the dependency root — common in financial models (a `TODAY()`/`OFFSET()`/`INDIRECT()` cell that everything references) — each volatile's cone covers a large fraction of the graph, so the loop is **O(V·N)**.

This dominated evaluation entirely on a real 3.6 MB / ~167K-cell customer workbook (convexent/supermod#2130). Per-stage instrumentation of a single `evaluate_cell`:

```
source_cache_session     13.9µs
build_demand_subgraph      3.4µs (5 precedents)
create_schedule            9.4µs (4 layers)
evaluate_layers          215.9µs (5 vertices actually computed)
clear_dirty + redirty  219.07s     <-- the entire cost
```

It also defeated cross-call reuse: every `evaluate_cell` on a dirty target re-paid the full cost (no amortization), while `evaluate_all` paid it once.

## Fix

Replace the per-volatile loop with a **single traversal seeded with all volatile vertices sharing one `visited`/`affected` set**, mirroring `mark_dirty`'s seed-level expansion (dependents + name-dependents + range-dependents) up front, then one shared BFS. The set of vertices marked dirty is **identical** (dependents of volatiles still re-evaluate); only the redundant re-walking of overlapping cones is removed. O(N + edges).

## Results (Illuminav workbook)

| | before | after |
|---|---|---|
| `evaluate_cell` | 219.2s | **0.32s** (~690×) |
| `evaluate_all` | 227.6s | **8.69s** (~26×) |
| `redirty_volatiles` alone | 219.07s | **0.174s** |

Values unchanged. `cargo test -p formualizer-eval` = 1244 passed; only the 3 pre-existing IMEXP/IMSIN/IMCOS complex-precision failures (no regression).

A regression guard is being added in a follow-up commit on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)